### PR TITLE
Start from copy of Embulk v0.9.0's org.embulk.spi.time.RubyTime* classes and their dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+  - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
+    compile "joda-time:joda-time:2.9.2"
     testCompile "junit:junit:4.12"
 }
 

--- a/src/main/java/org/embulk/config/UserDataException.java
+++ b/src/main/java/org/embulk/config/UserDataException.java
@@ -1,0 +1,3 @@
+package org.embulk.config;
+
+public interface UserDataException {}

--- a/src/main/java/org/embulk/spi/DataException.java
+++ b/src/main/java/org/embulk/spi/DataException.java
@@ -1,0 +1,17 @@
+package org.embulk.spi;
+
+import org.embulk.config.UserDataException;
+
+public class DataException extends RuntimeException implements UserDataException {
+    public DataException(String message) {
+        super(message);
+    }
+
+    public DataException(Throwable cause) {
+        super(cause);
+    }
+
+    public DataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/embulk/spi/time/LegacyRubyTimeParsed.java
+++ b/src/main/java/org/embulk/spi/time/LegacyRubyTimeParsed.java
@@ -1,0 +1,65 @@
+package org.embulk.spi.time;
+
+import java.time.Instant;
+import java.time.ZoneId;
+
+/**
+ * LegacyRubyTimeParsed is a variation of RubyTimeParsed, which is converted to Instant in legacy Embulk's way.
+ */
+class LegacyRubyTimeParsed extends RubyTimeParsed {
+    LegacyRubyTimeParsed(
+            final String originalString,
+
+            final int dayOfMonth,
+            final int weekBasedYear,
+            final int hour,
+            final int dayOfYear,
+            final int nanoOfSecond,
+            final int minuteOfHour,
+            final int monthOfYear,
+            final Instant instantSeconds,
+            final int secondOfMinute,
+            final int weekOfYearStartingWithSunday,
+            final int weekOfYearStartingWithMonday,
+            final int dayOfWeekStartingWithMonday1,
+            final int weekOfWeekBasedYear,
+            final int dayOfWeekStartingWithSunday0,
+            final int year,
+
+            final String timeZoneName,
+
+            final String leftover) {
+        super(originalString,
+
+              dayOfMonth,
+              weekBasedYear,
+              hour,
+              dayOfYear,
+              nanoOfSecond,
+              minuteOfHour,
+              monthOfYear,
+              instantSeconds,
+              secondOfMinute,
+              weekOfYearStartingWithSunday,
+              weekOfYearStartingWithMonday,
+              dayOfWeekStartingWithMonday1,
+              weekOfWeekBasedYear,
+              dayOfWeekStartingWithSunday0,
+              year,
+
+              timeZoneName,
+
+              leftover);
+    }
+
+    @Override
+    Instant toInstant(final int defaultYear,
+                      final int defaultMonthOfYear,
+                      final int defaultDayOfMonth,
+                      final ZoneId defaultZoneId) {
+        return this.toInstantLegacy(defaultYear,
+                                    defaultMonthOfYear,
+                                    defaultDayOfMonth,
+                                    defaultZoneId);
+    }
+}

--- a/src/main/java/org/embulk/spi/time/RubyTimeFormat.java
+++ b/src/main/java/org/embulk/spi/time/RubyTimeFormat.java
@@ -1,0 +1,187 @@
+package org.embulk.spi.time;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * RubyTimeFormat represents a Ruby-compatible time format.
+ *
+ * Embulk's timestamp formats are based on Ruby's formats for historical reasons, and kept for compatibility.
+ * Embulk maintains its own implementation of Ruby-compatible time parser to be independent from JRuby.
+ *
+ * This class is intentionally package-private so that plugins do not directly depend.
+ */
+class RubyTimeFormat implements Iterable<RubyTimeFormat.TokenWithNext> {
+    private RubyTimeFormat(final List<RubyTimeFormatToken> compiledPattern) {
+        this.compiledPattern = Collections.unmodifiableList(compiledPattern);
+    }
+
+    public static RubyTimeFormat compile(final String formatString) {
+        return new RubyTimeFormat(CompilerForParser.compile(formatString));
+    }
+
+    static RubyTimeFormat createForTesting(final List<RubyTimeFormatToken> compiledPattern) {
+        return new RubyTimeFormat(compiledPattern);
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (!(otherObject instanceof RubyTimeFormat)) {
+            return false;
+        }
+        final RubyTimeFormat other = (RubyTimeFormat) otherObject;
+        return this.compiledPattern.equals(other.compiledPattern);
+    }
+
+    @Override
+    public Iterator<TokenWithNext> iterator() {
+        return new TokenIterator(this.compiledPattern.iterator());
+    }
+
+    static class TokenWithNext {
+        private TokenWithNext(final RubyTimeFormatToken token, final RubyTimeFormatToken nextToken) {
+            this.token = token;
+            this.nextToken = nextToken;
+        }
+
+        RubyTimeFormatToken getToken() {
+            return this.token;
+        }
+
+        RubyTimeFormatToken getNextToken() {
+            return this.nextToken;
+        }
+
+        private final RubyTimeFormatToken token;
+        private final RubyTimeFormatToken nextToken;
+    }
+
+    private static class CompilerForParser {
+        private CompilerForParser(final String formatString) {
+            this.formatString = formatString;
+        }
+
+        public static List<RubyTimeFormatToken> compile(final String formatString) {
+            return new CompilerForParser(formatString).compileInitial();
+        }
+
+        private List<RubyTimeFormatToken> compileInitial() {
+            this.index = 0;
+            this.resultTokens = new ArrayList<>();
+            this.rawStringBuffer = new StringBuilder();
+
+            while (this.index < this.formatString.length()) {
+                final char cur = this.formatString.charAt(this.index);
+                switch (cur) {
+                    case '%':
+                        if (this.rawStringBuffer.length() > 0) {
+                            this.resultTokens.add(new RubyTimeFormatToken.Immediate(this.rawStringBuffer.toString()));
+                        }
+                        this.rawStringBuffer = new StringBuilder();
+                        this.index++;
+                        if (!this.compileDirective(this.index)) {
+                            this.rawStringBuffer.append(cur);  // Add '%', and go next ordinarily.
+                        }
+                        break;
+                    default:
+                        this.rawStringBuffer.append(cur);
+                        this.index++;
+                }
+            }
+            if (this.rawStringBuffer.length() > 0) {
+                this.resultTokens.add(new RubyTimeFormatToken.Immediate(this.rawStringBuffer.toString()));
+            }
+
+            return Collections.unmodifiableList(this.resultTokens);
+        }
+
+        private boolean compileDirective(final int beginningIndex) {
+            if (beginningIndex >= this.formatString.length()) {
+                return false;
+            }
+            final char cur = this.formatString.charAt(beginningIndex);
+            switch (cur) {
+                case 'E':
+                    if (beginningIndex + 1 < this.formatString.length()
+                            && "cCxXyY".indexOf(this.formatString.charAt(beginningIndex + 1)) >= 0) {
+                        return this.compileDirective(beginningIndex + 1);
+                    } else {
+                        return false;
+                    }
+                case 'O':
+                    if (beginningIndex + 1 < this.formatString.length()
+                            && "deHImMSuUVwWy".indexOf(this.formatString.charAt(beginningIndex + 1)) >= 0) {
+                        return this.compileDirective(beginningIndex + 1);
+                    } else {
+                        return false;
+                    }
+                case ':':
+                    for (int i = 1; i <= 3; ++i) {
+                        if (beginningIndex + i >= this.formatString.length()) {
+                            return false;
+                        }
+                        if (this.formatString.charAt(beginningIndex + i) == 'z') {
+                            return this.compileDirective(beginningIndex + i);
+                        }
+                        if (this.formatString.charAt(beginningIndex + i) != ':') {
+                            return false;
+                        }
+                    }
+                    return false;
+                case '%':
+                    this.resultTokens.add(new RubyTimeFormatToken.Immediate("%"));
+                    this.index = beginningIndex + 1;
+                    return true;
+                default:
+                    if (RubyTimeFormatDirective.isSpecifier(cur)) {
+                        this.resultTokens.addAll(RubyTimeFormatDirective.of(cur).toTokens());
+                        this.index = beginningIndex + 1;
+                        return true;
+                    } else {
+                        return false;
+                    }
+            }
+        }
+
+        private final String formatString;
+
+        private int index;
+        private List<RubyTimeFormatToken> resultTokens;
+        private StringBuilder rawStringBuffer;
+    }
+
+    private static class TokenIterator implements Iterator<TokenWithNext> {
+        private TokenIterator(final Iterator<RubyTimeFormatToken> initialIterator) {
+            this.internalIterator = initialIterator;
+            if (initialIterator.hasNext()) {
+                this.next = initialIterator.next();
+            } else {
+                this.next = null;
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return this.next != null;
+        }
+
+        @Override
+        public TokenWithNext next() {
+            final TokenWithNext tokenWithNext;
+            if (this.internalIterator.hasNext()) {
+                tokenWithNext = new TokenWithNext(this.next, this.internalIterator.next());
+            } else {
+                tokenWithNext = new TokenWithNext(this.next, null);
+            }
+            this.next = tokenWithNext.getNextToken();
+            return tokenWithNext;
+        }
+
+        private final Iterator<RubyTimeFormatToken> internalIterator;
+        private RubyTimeFormatToken next;
+    }
+
+    private final List<RubyTimeFormatToken> compiledPattern;
+}

--- a/src/main/java/org/embulk/spi/time/RubyTimeFormatDirective.java
+++ b/src/main/java/org/embulk/spi/time/RubyTimeFormatDirective.java
@@ -1,0 +1,185 @@
+package org.embulk.spi.time;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RubyTimeFormatDirective enumerates constants to represent Ruby-compatible time format directives.
+ *
+ * Embulk's timestamp formats are based on Ruby's formats for historical reasons, and kept for compatibility.
+ * Embulk maintains its own implementation of Ruby-compatible time parser to be independent from JRuby.
+ *
+ * This class is intentionally package-private so that plugins do not directly depend.
+ *
+ * @see <a href="https://docs.ruby-lang.org/en/2.4.0/Time.html#method-i-strftime">Ruby v2.4.0's datetime format</a>
+ */
+enum RubyTimeFormatDirective {
+    // Date (Year, Month, Day):
+
+    YEAR_WITH_CENTURY(true, 'Y'),
+    CENTURY(true, 'C'),
+    YEAR_WITHOUT_CENTURY(true, 'y'),
+
+    MONTH_OF_YEAR(true, 'm'),
+    MONTH_OF_YEAR_FULL_NAME(false, 'B'),
+    MONTH_OF_YEAR_ABBREVIATED_NAME(false, 'b'),
+    MONTH_OF_YEAR_ABBREVIATED_NAME_ALIAS_SMALL_H(false, 'h'),
+
+    DAY_OF_MONTH_ZERO_PADDED(true, 'd'),
+    DAY_OF_MONTH_BLANK_PADDED(true, 'e'),
+
+    DAY_OF_YEAR(true, 'j'),
+
+    // Time (Hour, Minute, Second, Subsecond):
+
+    HOUR_OF_DAY_ZERO_PADDED(true, 'H'),
+    HOUR_OF_DAY_BLANK_PADDED(true, 'k'),
+    HOUR_OF_AMPM_ZERO_PADDED(true, 'I'),
+    HOUR_OF_AMPM_BLANK_PADDED(true, 'l'),
+    AMPM_OF_DAY_LOWER_CASE(false, 'P'),
+    AMPM_OF_DAY_UPPER_CASE(false, 'p'),
+
+    MINUTE_OF_HOUR(true, 'M'),
+
+    SECOND_OF_MINUTE(true, 'S'),
+
+    MILLI_OF_SECOND(true, 'L'),
+    NANO_OF_SECOND(true, 'N'),
+
+    // Time zone:
+
+    TIME_OFFSET(false, 'z'),
+    TIME_ZONE_NAME(false, 'Z'),
+
+    // Weekday:
+
+    DAY_OF_WEEK_FULL_NAME(false, 'A'),
+    DAY_OF_WEEK_ABBREVIATED_NAME(false, 'a'),
+    DAY_OF_WEEK_STARTING_WITH_MONDAY_1(true, 'u'),
+    DAY_OF_WEEK_STARTING_WITH_SUNDAY_0(true, 'w'),
+
+    // ISO 8601 week-based year and week number:
+    // The first week of YYYY starts with a Monday and includes YYYY-01-04.
+    // The days in the year before the first week are in the last week of
+    // the previous year.
+
+    WEEK_BASED_YEAR_WITH_CENTURY(true, 'G'),
+    WEEK_BASED_YEAR_WITHOUT_CENTURY(true, 'g'),
+    WEEK_OF_WEEK_BASED_YEAR(true, 'V'),
+
+    // Week number:
+    // The first week of YYYY that starts with a Sunday or Monday (according to %U
+    // or %W). The days in the year before the first week are in week 0.
+
+    WEEK_OF_YEAR_STARTING_WITH_SUNDAY(true, 'U'),
+    WEEK_OF_YEAR_STARTING_WITH_MONDAY(true, 'W'),
+
+    // Seconds since the Epoch:
+
+    SECOND_SINCE_EPOCH(true, 's'),
+    MILLISECOND_SINCE_EPOCH(false, 'Q'),  // TODO: Revisit this "%Q" is not a numeric pattern?
+
+    // Recurred:
+
+    RECURRED_UPPER_C('c', "a b e H:M:S Y"),
+    RECURRED_UPPER_D('D', "m/d/y"),
+    RECURRED_LOWER_X('x', "m/d/y"),
+    RECURRED_UPPER_F('F', "Y-m-d"),
+    RECURRED_LOWER_N('n', "\n"),
+    RECURRED_UPPER_R('R', "H:M"),
+    RECURRED_LOWER_R('r', "I:M:S p"),
+    RECURRED_UPPER_T('T', "H:M:S"),
+    RECURRED_UPPER_X('X', "H:M:S"),
+    RECURRED_LOWER_T('t', "\t"),
+    RECURRED_LOWER_V('v', "e-b-Y"),
+    RECURRED_PLUS('+', "a b e H:M:S Z Y"),
+    ;
+
+    private RubyTimeFormatDirective(final boolean isNumeric, final char conversionSpecifier) {
+        this.conversionSpecifier = conversionSpecifier;
+        this.isNumeric = isNumeric;
+        this.isRecurred = false;
+        this.recurred = null;
+    }
+
+    private RubyTimeFormatDirective(final char conversionSpecifier, final String recurred) {
+        this.conversionSpecifier = conversionSpecifier;
+        this.isNumeric = false;
+        this.isRecurred = true;
+        this.recurred = recurred;
+    }
+
+    private RubyTimeFormatDirective() {
+        this(false, '\0');
+    }
+
+    static boolean isSpecifier(final char conversionSpecifier) {
+        return FROM_CONVERSION_SPECIFIER.containsKey(conversionSpecifier);
+    }
+
+    static RubyTimeFormatDirective of(final char conversionSpecifier) {
+        return FROM_CONVERSION_SPECIFIER.get(conversionSpecifier);
+    }
+
+    @Override
+    public String toString() {
+        return "" + this.conversionSpecifier;
+    }
+
+    boolean isNumeric() {
+        return this.isNumeric;
+    }
+
+    List<RubyTimeFormatToken> toTokens() {
+        return TO_TOKENS.get(this);
+    }
+
+    static {
+        final HashMap<Character, RubyTimeFormatDirective> charDirectiveMapBuilt = new HashMap<>();
+        for (final RubyTimeFormatDirective directive : values()) {
+            if (directive.conversionSpecifier != '\0') {
+                charDirectiveMapBuilt.put(directive.conversionSpecifier, directive);
+            }
+        }
+        FROM_CONVERSION_SPECIFIER = Collections.unmodifiableMap(charDirectiveMapBuilt);
+
+        final EnumMap<RubyTimeFormatDirective, List<RubyTimeFormatToken>> directiveTokensMapBuilt =
+                new EnumMap<>(RubyTimeFormatDirective.class);
+        for (final RubyTimeFormatDirective directive : values()) {
+            // Non-recurred directives first so that recurred directives can use tokens of non-recurred directives.
+            if (!directive.isRecurred) {
+                final ArrayList<RubyTimeFormatToken> tokensBuilt = new ArrayList<>();
+                tokensBuilt.add(new RubyTimeFormatToken.Directive(directive));
+                directiveTokensMapBuilt.put(directive, Collections.unmodifiableList(tokensBuilt));
+            }
+        }
+        for (final RubyTimeFormatDirective directive : values()) {
+            if (directive.isRecurred) {
+                final ArrayList<RubyTimeFormatToken> tokensBuilt = new ArrayList<>();
+                for (int i = 0; i < directive.recurred.length(); ++i) {
+                    final RubyTimeFormatDirective eachDirective =
+                            charDirectiveMapBuilt.get(directive.recurred.charAt(i));
+                    if (eachDirective == null) {
+                        tokensBuilt.add(new RubyTimeFormatToken.Immediate(directive.recurred.charAt(i)));
+                    } else {
+                        tokensBuilt.add(directiveTokensMapBuilt.get(eachDirective).get(0));
+                    }
+                }
+                directiveTokensMapBuilt.put(directive, Collections.unmodifiableList(tokensBuilt));
+            }
+        }
+        TO_TOKENS = Collections.unmodifiableMap(directiveTokensMapBuilt);
+    }
+
+    private static final Map<Character, RubyTimeFormatDirective> FROM_CONVERSION_SPECIFIER;
+    private static final Map<RubyTimeFormatDirective, List<RubyTimeFormatToken>> TO_TOKENS;
+
+    private final char conversionSpecifier;
+    private final boolean isNumeric;
+    private final boolean isRecurred;
+    private final String recurred;
+}

--- a/src/main/java/org/embulk/spi/time/RubyTimeFormatToken.java
+++ b/src/main/java/org/embulk/spi/time/RubyTimeFormatToken.java
@@ -1,0 +1,79 @@
+package org.embulk.spi.time;
+
+/**
+ * RubyTimeFormatToken represents a token in Ruby-compatible time format strings.
+ *
+ * Embulk's timestamp formats are based on Ruby's formats for historical reasons, and kept for compatibility.
+ * Embulk maintains its own implementation of Ruby-compatible time parser to be independent from JRuby.
+ *
+ * This class is intentionally package-private so that plugins do not directly depend.
+ */
+abstract class RubyTimeFormatToken {
+    abstract boolean isDirective();
+
+    static class Directive extends RubyTimeFormatToken {
+        Directive(final RubyTimeFormatDirective formatDirective) {
+            this.formatDirective = formatDirective;
+        }
+
+        @Override
+        public boolean equals(final Object otherObject) {
+            if (!(otherObject instanceof Directive)) {
+                return false;
+            }
+            final Directive other = (Directive) otherObject;
+            return this.formatDirective.equals(other.formatDirective);
+        }
+
+        @Override
+        public String toString() {
+            return "<%" + this.formatDirective.toString() + ">";
+        }
+
+        @Override
+        boolean isDirective() {
+            return true;
+        }
+
+        RubyTimeFormatDirective getFormatDirective() {
+            return this.formatDirective;
+        }
+
+        private final RubyTimeFormatDirective formatDirective;
+    }
+
+    static class Immediate extends RubyTimeFormatToken {
+        Immediate(final char character) {
+            this.string = "" + character;
+        }
+
+        Immediate(final String string) {
+            this.string = string;
+        }
+
+        @Override
+        public boolean equals(final Object otherObject) {
+            if (!(otherObject instanceof Immediate)) {
+                return false;
+            }
+            final Immediate other = (Immediate) otherObject;
+            return this.string.equals(other.string);
+        }
+
+        @Override
+        public String toString() {
+            return "<\"" + this.string + "\">";
+        }
+
+        @Override
+        boolean isDirective() {
+            return false;
+        }
+
+        String getContent() {
+            return this.string;
+        }
+
+        private final String string;
+    }
+}

--- a/src/main/java/org/embulk/spi/time/RubyTimeParsed.java
+++ b/src/main/java/org/embulk/spi/time/RubyTimeParsed.java
@@ -1,0 +1,989 @@
+package org.embulk.spi.time;
+
+import java.math.BigDecimal;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * RubyTimeParsed is TimeParsed from Ruby-style date/time formats.
+ *
+ * Embulk's timestamp formats are based on Ruby's formats for historical reasons, and kept for compatibility.
+ * Embulk maintains its own implementation of Ruby-compatible time parser to be independent from JRuby.
+ *
+ * This class is intentionally package-private so that plugins do not directly depend.
+ *
+ * A part of this class is reimplementation of Ruby v2.3.1's lib/time.rb. See its COPYING for license.
+ *
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup">lib/time.rb</a>
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/COPYING?view=markup">COPYING</a>
+ */
+class RubyTimeParsed extends TimeParsed {
+    // TODO: Make it private once LegacyRubyTimeParsed is removed.
+    RubyTimeParsed(
+            final String originalString,
+
+            final int dayOfMonth,
+            final int weekBasedYear,
+            final int hour,
+            final int dayOfYear,
+            final int nanoOfSecond,
+            final int minuteOfHour,
+            final int monthOfYear,
+            final Instant instantSeconds,
+            final int secondOfMinute,
+            final int weekOfYearStartingWithSunday,
+            final int weekOfYearStartingWithMonday,
+            final int dayOfWeekStartingWithMonday1,
+            final int weekOfWeekBasedYear,
+            final int dayOfWeekStartingWithSunday0,
+            final int year,
+
+            final String timeZoneName,
+
+            final String leftover) {
+        this.originalString = originalString;
+
+        this.dayOfMonth = dayOfMonth;
+        this.weekBasedYear = weekBasedYear;
+        this.hour = hour;
+        this.dayOfYear = dayOfYear;
+        this.nanoOfSecond = nanoOfSecond;
+        this.minuteOfHour = minuteOfHour;
+        this.monthOfYear = monthOfYear;
+        this.instantSeconds = instantSeconds;
+        this.secondOfMinute = secondOfMinute;
+        this.weekOfYearStartingWithSunday = weekOfYearStartingWithSunday;
+        this.weekOfYearStartingWithMonday = weekOfYearStartingWithMonday;
+        this.dayOfWeekStartingWithMonday1 = dayOfWeekStartingWithMonday1;
+        this.weekOfWeekBasedYear = weekOfWeekBasedYear;
+        this.dayOfWeekStartingWithSunday0 = dayOfWeekStartingWithSunday0;
+        this.year = year;
+
+        this.timeZoneName = timeZoneName;
+
+        this.leftover = leftover;
+    }
+
+    static class Builder {
+        Builder(final String originalString) {
+            this.originalString = originalString;
+
+            this.century = Integer.MIN_VALUE;
+            this.dayOfMonth = Integer.MIN_VALUE;
+            this.weekBasedYear = Integer.MIN_VALUE;
+            this.hour = Integer.MIN_VALUE;
+            this.dayOfYear = Integer.MIN_VALUE;
+            this.nanoOfSecond = Integer.MIN_VALUE;
+            this.minuteOfHour = Integer.MIN_VALUE;
+            this.monthOfYear = Integer.MIN_VALUE;
+            this.ampmOfDay = Integer.MIN_VALUE;
+            this.instantSeconds = null;
+            this.secondOfMinute = Integer.MIN_VALUE;
+            this.weekOfYearStartingWithSunday = Integer.MIN_VALUE;
+            this.weekOfYearStartingWithMonday = Integer.MIN_VALUE;
+            this.dayOfWeekStartingWithMonday1 = Integer.MIN_VALUE;
+            this.weekOfWeekBasedYear = Integer.MIN_VALUE;
+            this.dayOfWeekStartingWithSunday0 = Integer.MIN_VALUE;
+            this.year = Integer.MIN_VALUE;
+
+            this.timeZoneName = null;
+
+            this.leftover = null;
+
+            this.fail = false;
+        }
+
+        RubyTimeParsed build() {
+            // Merge week-based year and century as MRI (Matz' Ruby Implementation) does before generating a hash.
+            // See: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l676
+            final int weekBasedYearWithCentury;
+            if (this.century != Integer.MIN_VALUE && this.weekBasedYear != Integer.MIN_VALUE) {
+                // It is the right behavior in Ruby.
+                // Date._strptime('13 1234', '%C %G') => {:cwyear=>2534}
+                weekBasedYearWithCentury = this.century * 100 + this.weekBasedYear;
+            } else {
+                weekBasedYearWithCentury = this.weekBasedYear;
+            }
+
+            // Merge year and century as MRI (Matz' Ruby Implementation) does before generating a hash.
+            // See: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l679
+            final int yearWithCentury;
+            if (this.century != Integer.MIN_VALUE && this.year != Integer.MIN_VALUE) {
+                // It is the right behavior in Ruby.
+                // Date._strptime('13 1234', '%C %Y') => {:year=>2534}
+                yearWithCentury = this.century * 100 + this.year;
+            } else {
+                yearWithCentury = this.year;
+            }
+
+            // Merge hour and ampmOfDay as MRI (Matz' Ruby Implementation) does before generating a hash.
+            // See: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l685
+            final int hourWithAmPm;
+            if (this.hour != Integer.MIN_VALUE && this.ampmOfDay != Integer.MIN_VALUE) {
+                hourWithAmPm = (this.hour % 12) + this.ampmOfDay;
+            } else {
+                hourWithAmPm = this.hour;
+            }
+
+            return new RubyTimeParsed(
+                    this.originalString,
+
+                    this.dayOfMonth,
+                    weekBasedYearWithCentury,
+                    hourWithAmPm,
+                    this.dayOfYear,
+                    this.nanoOfSecond,
+                    this.minuteOfHour,
+                    this.monthOfYear,
+                    this.instantSeconds,
+                    this.secondOfMinute,
+                    this.weekOfYearStartingWithSunday,
+                    this.weekOfYearStartingWithMonday,
+                    this.dayOfWeekStartingWithMonday1,
+                    this.weekOfWeekBasedYear,
+                    this.dayOfWeekStartingWithSunday0,
+                    yearWithCentury,
+
+                    this.timeZoneName,
+
+                    this.leftover);
+        }
+
+        /**
+         * Sets day of the week by name.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: wday
+         * <li> Ruby strptime directive specifier related: %A, %a
+         * <li> java.time.temporal:
+         * </ul>
+         */
+        Builder setDayOfWeekByName(final String dayOfWeekByName) {
+            final Integer dayOfWeek = DAY_OF_WEEK_NAMES.get(dayOfWeekByName);
+            if (dayOfWeek == null) {
+                fail = true;
+            } else {
+                this.dayOfWeekStartingWithSunday0 = dayOfWeek;
+            }
+            return this;
+        }
+
+        /**
+         * Sets month of the year by name.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: mon
+         * <li> Ruby strptime directive specifier related: %B, %b, %h
+         * <li> java.time.temporal:
+         * </ul>
+         */
+        Builder setMonthOfYearByName(final String monthOfYearByName) {
+            final Integer monthOfYear = MONTH_OF_YEAR_NAMES.get(monthOfYearByName);
+            if (monthOfYear == null) {
+                fail = true;
+            } else {
+                this.monthOfYear = monthOfYear;
+            }
+            return this;
+        }
+
+        /**
+         * Sets century.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: _cent
+         * <li> Ruby strptime directive specifier related: %C
+         * <li> java.time.temporal: N/A
+         * </ul>
+         */
+        Builder setCentury(final int century) {
+            this.century = century;
+            return this;
+        }
+
+        /**
+         * Sets day of the month.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: mday
+         * <li> Ruby strptime directive specifier related: %d, %e
+         * <li> java.time.temporal: ChronoField.DAY_OF_MONTH
+         * </ul>
+         */
+        Builder setDayOfMonth(final int dayOfMonth) {
+            this.dayOfMonth = dayOfMonth;
+            return this;
+        }
+
+        /**
+         * Sets week-based year.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: cwyear
+         * <li> Ruby strptime directive specifier related: %G
+         * <li> java.time.temporal: N/A
+         * </ul>
+         */
+        Builder setWeekBasedYear(final int weekBasedYear) {
+            this.weekBasedYear = weekBasedYear;
+            return this;
+        }
+
+        /**
+         * Sets week-based year without century.
+         *
+         * If century is not set before by setCentury (%C), it tries to set default century as well.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: cwyear
+         * <li> Ruby strptime directive specifier related: %g
+         * <li> java.time.temporal: N/A
+         * </ul>
+         */
+        Builder setWeekBasedYearWithoutCentury(final int weekBasedYearWithoutCentury) {
+            this.weekBasedYear = weekBasedYearWithoutCentury;
+            if (this.century == Integer.MIN_VALUE) {
+                this.century = (weekBasedYearWithoutCentury >= 69 ? 19 : 20);
+            }
+            return this;
+        }
+
+        /**
+         * Sets hour.
+         *
+         * The hour can be either in 12-hour or 24-hour. It is considered 12-hour if setAmPmOfDay (%P/%p) is set.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: hour
+         * <li> Ruby strptime directive specifier related: %H, %k, %I, %l
+         * <li> java.time.temporal: ChronoField.HOUR_OF_AMPM or ChronoField.HOUR_OF_DAY
+         * </ul>
+         */
+        Builder setHour(final int hour) {
+            this.hour = hour;
+            return this;
+        }
+
+        /**
+         * Sets day of the year.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: yday
+         * <li> Ruby strptime directive specifier related: %j
+         * <li> java.time.temporal: ChronoField.DAY_OF_YEAR
+         * </ul>
+         */
+        Builder setDayOfYear(final int dayOfYear) {
+            this.dayOfYear = dayOfYear;
+            return this;
+        }
+
+        /**
+         * Sets fractional part of the second.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: sec_fraction
+         * <li> Ruby strptime directive specifier related: %L, %N
+         * <li> java.time.temporal:
+         * </ul>
+         */
+        Builder setNanoOfSecond(final int nanoOfSecond) {
+            this.nanoOfSecond = nanoOfSecond;
+            return this;
+        }
+
+        /**
+         * Sets minute of the hour.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: min
+         * <li> Ruby strptime directive specifier related: %M
+         * <li> java.time.temporal: ChronoField.MINUTE_OF_HOUR
+         * </ul>
+         */
+        Builder setMinuteOfHour(final int minuteOfHour) {
+            this.minuteOfHour = minuteOfHour;
+            return this;
+        }
+
+        /**
+         * Sets month of the year.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: mon
+         * <li> Ruby strptime directive specifier related: %m
+         * <li> java.time.temporal: ChronoField.MONTH_OF_YEAR
+         * </ul>
+         */
+        Builder setMonthOfYear(final int monthOfYear) {
+            this.monthOfYear = monthOfYear;
+            return this;
+        }
+
+        /**
+         * Sets am/pm of the day.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: _merid
+         * <li> Ruby strptime directive specifier related: %P, %p
+         * <li> java.time.temporal: ChronoField.AMPM_OF_DAY
+         * </ul>
+         */
+        Builder setAmPmOfDay(final int ampmOfDay) {
+            this.ampmOfDay = ampmOfDay;
+            return this;
+        }
+
+        /**
+         * Sets second since the epoch.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: seconds
+         * <li> Ruby strptime directive specifier related: %Q, %s
+         * <li> java.time.temporal: ChronoField.INSTANT_SECONDS
+         * </ul>
+         */
+        Builder setInstantSeconds(final Instant instantSeconds) {
+            this.instantSeconds = instantSeconds;
+            return this;
+        }
+
+        /**
+         * Sets second of the minute.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: sec
+         * <li> Ruby strptime directive specifier related: %S
+         * <li> java.time.temporal: ChronoField.SECOND_OF_MINUTE
+         * </ul>
+         */
+        Builder setSecondOfMinute(final int secondOfMinute) {
+            this.secondOfMinute = secondOfMinute;
+            return this;
+        }
+
+        /**
+         * Sets week number with weeks starting from Sunday.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: wnum0
+         * <li> Ruby strptime directive specifier related: %U
+         * <li> java.time.temporal:
+         * </ul>
+         */
+        Builder setWeekOfYearStartingWithSunday(final int weekOfYearStartingWithSunday) {
+            this.weekOfYearStartingWithSunday = weekOfYearStartingWithSunday;
+            return this;
+        }
+
+        /**
+         * Sets week number with weeks starting from Monday.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: wnum1
+         * <li> Ruby strptime directive specifier related: %W
+         * <li> java.time.temporal:
+         * </ul>
+         */
+        Builder setWeekOfYearStartingWithMonday(final int weekOfYearStartingWithMonday) {
+            this.weekOfYearStartingWithMonday = weekOfYearStartingWithMonday;
+            return this;
+        }
+
+        /**
+         * Sets day of week starting from Monday with 1.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: cwday
+         * <li> Ruby strptime directive specifier related: %u
+         * <li> java.time.temporal:
+         * </ul>
+         */
+        Builder setDayOfWeekStartingWithMonday1(final int dayOfWeekStartingWithMonday1) {
+            this.dayOfWeekStartingWithMonday1 = dayOfWeekStartingWithMonday1;
+            return this;
+        }
+
+        /**
+         * Sets week number of week-based year.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: cweek
+         * <li> Ruby strptime directive specifier related: %V
+         * <li> java.time.temporal:
+         * </ul>
+         */
+        Builder setWeekOfWeekBasedYear(final int weekOfWeekBasedYear) {
+            this.weekOfWeekBasedYear = weekOfWeekBasedYear;
+            return this;
+        }
+
+        /**
+         * Sets day of week starting from Sunday with 0.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: wday
+         * <li> Ruby strptime directive specifier related: %w
+         * <li> java.time.temporal:
+         * </ul>
+         */
+        Builder setDayOfWeekStartingWithSunday0(final int dayOfWeekStartingWithSunday0) {
+            this.dayOfWeekStartingWithSunday0 = dayOfWeekStartingWithSunday0;
+            return this;
+        }
+
+        /**
+         * Sets year.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: year
+         * <li> Ruby strptime directive specifier related: %Y
+         * <li> java.time.temporal: ChronoField.YEAR
+         * </ul>
+         */
+        Builder setYear(final int year) {
+            this.year = year;
+            return this;
+        }
+
+        /**
+         * Sets year without century.
+         *
+         * If century is not set before by setCentury (%C), it tries to set default century as well.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: year
+         * <li> Ruby strptime directive specifier related: %y
+         * <li> java.time.temporal: ChronoField.YEAR
+         * </ul>
+         */
+        Builder setYearWithoutCentury(final int yearWithoutCentury) {
+            this.year = yearWithoutCentury;
+            if (this.century == Integer.MIN_VALUE) {
+                this.century = (yearWithoutCentury >= 69 ? 19 : 20);
+            }
+            return this;
+        }
+
+        /**
+         * Sets time offset.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: zone, offset
+         * <li> Ruby strptime directive specifier related: %Z, %z
+         * <li> java.time.temporal: ChronoField.OFFSET_SECONDS (not exactly the same)
+         * </ul>
+         */
+        Builder setTimeOffset(final String timeZoneName) {
+            this.timeZoneName = timeZoneName;
+            return this;
+        }
+
+        /**
+         * Sets leftover.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: leftover
+         * <li> Ruby strptime directive specifier related: N/A
+         * <li> java.time.temporal: N/A
+         * </ul>
+         */
+        Builder setLeftover(final String leftover) {
+            this.leftover = leftover;
+            return this;
+        }
+
+        private static final Map<String, Integer> DAY_OF_WEEK_NAMES;
+        private static final Map<String, Integer> MONTH_OF_YEAR_NAMES;
+
+        private static final String[] DAY_OF_WEEK_FULL_NAMES = new String[] {
+                "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+        };
+
+        private static final String[] DAY_OF_WEEK_ABBREVIATED_NAMES = new String[] {
+                "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+        };
+
+        private static final String[] MONTH_OF_YEAR_FULL_NAMES = new String[] {
+                "January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December"
+        };
+
+        private static final String[] MONTH_OF_YEAR_ABBREVIATED_NAMES = new String[] {
+                "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+        };
+
+        static {
+            final HashMap<String, Integer> dayOfWeekNamesBuilt = new HashMap<>();
+            for (int i = 0; i < DAY_OF_WEEK_FULL_NAMES.length; ++i) {
+                dayOfWeekNamesBuilt.put(DAY_OF_WEEK_FULL_NAMES[i], i);
+            }
+            for (int i = 0; i < DAY_OF_WEEK_ABBREVIATED_NAMES.length; ++i) {
+                dayOfWeekNamesBuilt.put(DAY_OF_WEEK_ABBREVIATED_NAMES[i], i);
+            }
+            DAY_OF_WEEK_NAMES = Collections.unmodifiableMap(dayOfWeekNamesBuilt);
+
+            final HashMap<String, Integer> monthOfYearNamesBuilt = new HashMap<>();
+            for (int i = 0; i < MONTH_OF_YEAR_FULL_NAMES.length; ++i) {
+                monthOfYearNamesBuilt.put(MONTH_OF_YEAR_FULL_NAMES[i], i + 1);
+            }
+            for (int i = 0; i < MONTH_OF_YEAR_ABBREVIATED_NAMES.length; ++i) {
+                monthOfYearNamesBuilt.put(MONTH_OF_YEAR_ABBREVIATED_NAMES[i], i + 1);
+            }
+            MONTH_OF_YEAR_NAMES = Collections.unmodifiableMap(monthOfYearNamesBuilt);
+        }
+
+        private final String originalString;
+
+        private int century;
+        private int dayOfMonth;
+        private int weekBasedYear;
+        private int hour;
+        private int dayOfYear;
+        private int nanoOfSecond;
+        private int minuteOfHour;
+        private int monthOfYear;
+        private int ampmOfDay;
+        private Instant instantSeconds;
+        private int secondOfMinute;
+        private int weekOfYearStartingWithSunday;
+        private int weekOfYearStartingWithMonday;
+        private int dayOfWeekStartingWithMonday1;
+        private int weekOfWeekBasedYear;
+        private int dayOfWeekStartingWithSunday0;
+        private int year;
+
+        private String timeZoneName;
+
+        private String leftover;
+
+        private boolean fail;
+    }
+
+    /**
+     * Creates a java.time.Instant instance basically in the same way with Ruby v2.3.1's Time.strptime.
+     *
+     * The difference from Ruby v2.3.1's Time.strptime is that it does not consider "now" and local time zone.
+     * If the given zone is neither numerical nor predefined textual time zones, it returns defaultZoneOffset then.
+     *
+     * The method is reimplemented based on strptime from Ruby v2.3.1's lib/time.rb.
+     *
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l427">strptime</a>
+     */
+    @Override
+    Instant toInstant(final ZoneOffset defaultZoneOffset) {
+        final ZoneOffset zoneOffset = TimeZoneIds.parseRubyTimeZoneOffset(this.timeZoneName, defaultZoneOffset);
+        if (zoneOffset == null) {
+            throw new TimestampParseException(
+                    "Invalid time zone ID '" + this.timeZoneName + "' in '" + this.originalString + "'");
+        }
+
+        if (this.instantSeconds != null) {
+            // Fractions by %Q are prioritized over fractions by %N.
+            // irb(main):002:0> Time.strptime("123456789 12.345", "%Q %S.%N").nsec
+            // => 789000000
+            // irb(main):003:0> Time.strptime("12.345 123456789", "%S.%N %Q").nsec
+            // => 789000000
+            // irb(main):004:0> Time.strptime("12.345", "%S.%N").nsec
+            // => 345000000
+            if (!defaultZoneOffset.equals(ZoneOffset.UTC)) {
+                // TODO: Warn that a default time zone is specified for epoch seconds.
+            }
+            if (this.timeZoneName != null) {
+                // TODO: Warn that the epoch second has a time zone.
+            }
+            return this.instantSeconds;
+        }
+
+        // Day of the year (yday: DAY_OF_YEAR) is not considered in Time.strptime, not like DateTime.strptime.
+        //
+        // irb(main):002:0> Time.strptime("2001-128T23:59:59", "%Y-%jT%H:%M:%S")
+        // => 2001-01-01 23:59:59 +0900
+        // irb(main):004:0> DateTime.strptime("2001-128T23:59:59", "%Y-%jT%H:%M:%S")
+        // => #<DateTime: 2001-05-08T23:59:59+00:00 ((2452038j,86399s,0n),+0s,2299161j)>
+
+        final OffsetDateTime datetime = applyOffset(
+                (this.year == Integer.MIN_VALUE ? 1970 : this.year),
+                (this.monthOfYear == Integer.MIN_VALUE ? 1 : this.monthOfYear),
+                (this.dayOfMonth == Integer.MIN_VALUE ? 1 : this.dayOfMonth),
+                (this.hour == Integer.MIN_VALUE ? 0 : this.hour),
+                (this.minuteOfHour == Integer.MIN_VALUE ? 0 : this.minuteOfHour),
+                (this.secondOfMinute == Integer.MIN_VALUE ? 0 : this.secondOfMinute),
+                (this.nanoOfSecond == Integer.MIN_VALUE ? 0 : this.nanoOfSecond),
+                zoneOffset);
+
+        return datetime.toInstant();
+    }
+
+    @Override
+    Instant toInstant(final int defaultYear,
+                      final int defaultMonthOfYear,
+                      final int defaultDayOfMonth,
+                      final ZoneId defaultZoneId) {
+        // TODO: Implement it.
+        throw new UnsupportedOperationException("Non-legacy RubyTimeParsed is not implemented.");
+    }
+
+    /**
+     * Creates a java.time.Instant instance in legacy Embulk's way from this RubyTimeParsed instance with ZoneId.
+     *
+     * This method is to be called from LegacyRubyTimeParsed to access private fields.
+     *
+     * TODO: Remove this method once legacy Timestamp formats are removed.
+     */
+    final Instant toInstantLegacy(final int defaultYear,
+                                  final int defaultMonthOfYear,
+                                  final int defaultDayOfMonth,
+                                  final ZoneId defaultZoneId) {
+        if (this.instantSeconds != null) {
+            // Fractions by %Q are prioritized over fractions by %N.
+            // irb(main):002:0> Time.strptime("123456789 12.345", "%Q %S.%N").nsec
+            // => 789000000
+            // irb(main):003:0> Time.strptime("12.345 123456789", "%S.%N %Q").nsec
+            // => 789000000
+            // irb(main):004:0> Time.strptime("12.345", "%S.%N").nsec
+            // => 345000000
+            if (!defaultZoneId.equals(ZoneOffset.UTC)) {
+                // TODO: Warn that a default time zone is specified for epoch seconds.
+            }
+            if (this.timeZoneName != null) {
+                // TODO: Warn that the epoch second has a time zone.
+            }
+            return this.instantSeconds;
+        }
+
+        final ZoneId zoneId;
+        if (this.timeZoneName != null) {
+            zoneId = TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab(this.timeZoneName);
+            if (zoneId == null) {
+                throw new TimestampParseException(
+                        "Invalid time zone ID '" + this.timeZoneName + "' in '" + this.originalString + "'");
+            }
+        } else {
+            zoneId = defaultZoneId;
+        }
+
+        // Leap seconds are considered as 59 when Ruby converts them to epochs.
+        final int thisSecondOfMinute;
+        if (this.secondOfMinute == Integer.MIN_VALUE) {
+            thisSecondOfMinute = 0;
+        } else if (this.secondOfMinute == 60) {
+            thisSecondOfMinute = 59;
+        } else {
+            thisSecondOfMinute = this.secondOfMinute;
+        }
+
+        // TODO: Implement rolling over other than days if needed.
+        final int daysRollover = (this.hour == Integer.MIN_VALUE ? 0 : this.hour / 24);
+
+        final ZonedDateTime datetime;
+        // yday is more prioritized than mon/mday in Ruby's strptime.
+        if (this.dayOfYear != Integer.MIN_VALUE) {
+            datetime = ZonedDateTime.of(
+                    (this.year == Integer.MIN_VALUE ? defaultYear : this.year),
+                    1,
+                    1,
+                    (this.hour == Integer.MIN_VALUE ? 0 : this.hour % 24),
+                    (this.minuteOfHour == Integer.MIN_VALUE ? 0 : this.minuteOfHour),
+                    thisSecondOfMinute,
+                    (this.nanoOfSecond == Integer.MIN_VALUE ? 0 : this.nanoOfSecond),
+                    zoneId).withDayOfYear(this.dayOfYear).plusDays(daysRollover);
+        } else {
+            datetime = ZonedDateTime.of(
+                    (this.year == Integer.MIN_VALUE ? defaultYear : this.year),
+                    (this.monthOfYear == Integer.MIN_VALUE ? defaultMonthOfYear : this.monthOfYear),
+                    (this.dayOfMonth == Integer.MIN_VALUE ? defaultDayOfMonth : this.dayOfMonth),
+                    (this.hour == Integer.MIN_VALUE ? 0 : this.hour % 24),
+                    (this.minuteOfHour == Integer.MIN_VALUE ? 0 : this.minuteOfHour),
+                    thisSecondOfMinute,
+                    (this.nanoOfSecond == Integer.MIN_VALUE ? 0 : this.nanoOfSecond),
+                    zoneId).plusDays(daysRollover);
+        }
+        return datetime.toInstant();
+    }
+
+    /**
+     * Converts this RubyTimeParsed to LegacyRubyTimeParsed so that it can be converted to Instant in the legacy way.
+     *
+     * TODO: Remove this method once legacy Timestamp formats are removed.
+     */
+    final LegacyRubyTimeParsed toLegacy() {
+        return new LegacyRubyTimeParsed(
+                originalString,
+
+                dayOfMonth,
+                weekBasedYear,
+                hour,
+                dayOfYear,
+                nanoOfSecond,
+                minuteOfHour,
+                monthOfYear,
+                instantSeconds,
+                secondOfMinute,
+                weekOfYearStartingWithSunday,
+                weekOfYearStartingWithMonday,
+                dayOfWeekStartingWithMonday1,
+                weekOfWeekBasedYear,
+                dayOfWeekStartingWithSunday0,
+                year,
+
+                timeZoneName,
+
+                leftover);
+    }
+
+    final Map<String, Object> asMapLikeRubyHash() {
+        final HashMap<String, Object> hash = new HashMap<>();
+
+        putIntIfValid(hash, "mday", this.dayOfMonth);
+        putIntIfValid(hash, "cwyear", this.weekBasedYear);
+        putIntIfValid(hash, "hour", this.hour);
+        putIntIfValid(hash, "yday", this.dayOfYear);
+        putFractionIfValid(hash, "sec_fraction", this.nanoOfSecond);
+        putIntIfValid(hash, "min", this.minuteOfHour);
+        putIntIfValid(hash, "mon", this.monthOfYear);
+        putSecondWithFractionIfValid(hash, "seconds", this.instantSeconds);
+        putIntIfValid(hash, "sec", this.secondOfMinute);
+        putIntIfValid(hash, "wnum0", this.weekOfYearStartingWithSunday);
+        putIntIfValid(hash, "wnum1", this.weekOfYearStartingWithMonday);
+        putIntIfValid(hash, "cwday", this.dayOfWeekStartingWithMonday1);
+        putIntIfValid(hash, "cweek", this.weekOfWeekBasedYear);
+        putIntIfValid(hash, "wday", this.dayOfWeekStartingWithSunday0);
+        putIntIfValid(hash, "year", this.year);
+        putTimeZoneIfValid(hash, this.timeZoneName);
+        putStringIfValid(hash, "leftover", this.leftover);
+
+        return hash;
+    }
+
+    private int putIntIfValid(final Map<String, Object> hash, final String key, final int value) {
+        if (value != Integer.MIN_VALUE) {
+            hash.put(key, value);
+        }
+        return value;
+    }
+
+    private BigDecimal putFractionIfValid(final Map<String, Object> hash, final String key, final int value) {
+        if (value != Integer.MIN_VALUE) {
+            return (BigDecimal) hash.put(key, BigDecimal.ZERO.add(BigDecimal.valueOf(value, 9)));
+        }
+        return null;
+    }
+
+    private Object putSecondWithFractionIfValid(final Map<String, Object> hash, final String key, final Instant value) {
+        if (value != null) {
+            if (value.getNano() == 0) {
+                return hash.put(key, value.getEpochSecond());
+            } else {
+                return hash.put(key,
+                                BigDecimal.valueOf(value.getEpochSecond()).add(BigDecimal.valueOf(value.getNano(), 9)));
+            }
+        }
+        return null;
+    }
+
+    private String putTimeZoneIfValid(final Map<String, Object> hash, final String timeZoneName) {
+        if (timeZoneName != null) {
+            final int offset = RubyTimeZoneTab.dateZoneToDiff(timeZoneName);
+            if (offset != Integer.MIN_VALUE) {
+                hash.put("offset", offset);
+            }
+            return (String) hash.put("zone", timeZoneName);
+        }
+        return timeZoneName;
+    }
+
+    private String putStringIfValid(final Map<String, Object> hash, final String key, final String value) {
+        if (value != null) {
+            return (String) hash.put(key, value);
+        }
+        return value;
+    }
+
+    /**
+     * Applies time zone offset to date/time information, and creates java.time.OffsetDateTime in UTC.
+     *
+     * The method is reimplemented based on apply_offset from Ruby v2.3.1's lib/time.rb.
+     *
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l208">apply_offset</a>
+     */
+    private static OffsetDateTime applyOffset(int year,
+                                              int monthOfYear,
+                                              int dayOfMonth,
+                                              int hourOfDay,
+                                              int minuteOfHour,
+                                              int secondOfMinute,
+                                              final int nanoOfSecond,
+                                              final ZoneOffset zoneOffset) throws TimestampParseException {
+        int offset = zoneOffset.getTotalSeconds();
+
+        // Processing leap seconds using time offsets in a bit tricky manner.
+        //
+        // Leap seconds are considered as the next second in Time.strptime.
+        // irb(main):002:0> Time.strptime("2001-02-03T23:59:60", "%Y-%m-%dT%H:%M:%S")
+        // => 2001-02-04 00:00:00 +0900
+        if (secondOfMinute == 60) {
+            secondOfMinute = 59;
+            offset -= 1;
+        }
+
+        // Processing 24h in clock hours using time offsets in a bit tricky manner.
+        //
+        // 24h is considered as 0h in the next day in Time.strptime (if non-UTC time zone is specified).
+        // irb(main):002:0> Time.strptime("24:59:59 PST", "%H:%M:%S %Z")
+        // => 2018-01-13 00:59:59 -0800
+        // irb(main):003:0> Time.strptime("24:59:59 UTC", "%H:%M:%S %Z")
+        // ArgumentError: min out of range
+        // ...
+        // irb(main):004:0> Time.strptime("24:59:59", "%H:%M:%S")
+        // ArgumentError: min out of range
+        // ...
+        //
+        // 24h is always handled as 0h in the next day in Embulk as if non-UTC time zone is specified.
+        if (hourOfDay == 24) {
+            offset -= 24 * 60 * 60;
+            hourOfDay = 0;
+        }
+
+        if (offset < 0) {
+            offset = -offset;
+
+            final int offsetSecond = offset % 60;
+            offset = offset / 60;
+            if (offsetSecond != 0) {
+                secondOfMinute += offsetSecond;
+                offset += secondOfMinute / 60;
+                secondOfMinute %= 60;
+            }
+
+            final int offsetMinute = offset % 60;
+            offset = offset / 60;
+            if (offsetMinute != 0) {
+                minuteOfHour += offsetMinute;
+                offset += minuteOfHour / 60;
+                minuteOfHour %= 60;
+            }
+
+            final int offsetHour = offset % 24;
+            offset = offset / 24;
+            if (offsetHour != 0) {
+                hourOfDay += offsetHour;
+                offset += hourOfDay / 24;
+                hourOfDay %= 24;
+            }
+
+            if (offset != 0) {
+                dayOfMonth += offset;
+                final int days = monthDays(year, monthOfYear);
+                if (days < dayOfMonth) {
+                    monthOfYear += 1;
+                    if (12 < monthOfYear) {
+                        monthOfYear = 1;
+                        year += 1;
+                    }
+                    dayOfMonth = 1;
+                }
+            }
+
+        } else if (0 < offset) {
+            final int offsetSecond = offset % 60;
+            offset /= 60;
+            if (offsetSecond != 0) {
+                secondOfMinute -= offsetSecond;
+                offset -= secondOfMinute / 60;
+                secondOfMinute %= 60;
+            }
+
+            final int offsetMinute = offset % 60;
+            offset /= 60;
+            if (offsetMinute != 0) {
+                minuteOfHour -= offsetMinute;
+                offset -= minuteOfHour / 60;
+                minuteOfHour %= 60;
+            }
+
+            final int offsetHour = offset % 24;
+            offset /= 24;
+            if (offsetHour != 0) {
+                hourOfDay -= offsetHour;
+                offset -= hourOfDay / 24;
+                hourOfDay %= 24;
+            }
+
+            if (offset != 0) {
+                dayOfMonth -= offset;
+                if (dayOfMonth < 1) {
+                    monthOfYear -= 1;
+                    if (monthOfYear < 1) {
+                        year -= 1;
+                        monthOfYear = 12;
+                    }
+                    dayOfMonth = monthDays(year, monthOfYear);
+                }
+            }
+        }
+
+        try {
+            return OffsetDateTime.of(year, monthOfYear, dayOfMonth,
+                                     hourOfDay, minuteOfHour, secondOfMinute, nanoOfSecond,
+                                     ZoneOffset.UTC);
+        } catch (DateTimeException ex) {
+            throw new TimestampParseException(ex);
+        }
+    }
+
+    /**
+     * Returns the number of days in the given month of the given year.
+     *
+     * The method is reimplemented based on month_days from Ruby v2.3.1's lib/time.rb.
+     *
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l199">month_days</a>
+     */
+    private static int monthDays(final int year, final int monthOfYear) {
+        if (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)) {
+            return leapYearMonthDays[monthOfYear - 1];
+        } else {
+            return commonYearMonthDays[monthOfYear - 1];
+        }
+    }
+
+    private final String originalString;
+
+    private final int dayOfMonth;
+    private final int weekBasedYear;
+    private final int hour;
+    private final int dayOfYear;
+    private final int nanoOfSecond;
+    private final int minuteOfHour;
+    private final int monthOfYear;
+    private final Instant instantSeconds;
+    private final int secondOfMinute;
+    private final int weekOfYearStartingWithSunday;
+    private final int weekOfYearStartingWithMonday;
+    private final int dayOfWeekStartingWithMonday1;
+    private final int weekOfWeekBasedYear;
+    private final int dayOfWeekStartingWithSunday0;
+    private final int year;
+
+    private final String timeZoneName;
+
+    private final String leftover;
+
+    /**
+     * Numbers of days per month and year.
+     *
+     * The constants are imported from LeapYearMonthDays and CommonYearMonthDays in Ruby v2.3.1's lib/time.rb.
+     *
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l197">LeapYearMonthDays</a>
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l198">CommonYearMonthDays</a>
+     */
+    private static final int[] leapYearMonthDays = { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+    private static final int[] commonYearMonthDays = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+}

--- a/src/main/java/org/embulk/spi/time/RubyTimeParser.java
+++ b/src/main/java/org/embulk/spi/time/RubyTimeParser.java
@@ -1,0 +1,536 @@
+package org.embulk.spi.time;
+
+import java.time.Instant;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * RubyTimeParser is a Ruby-compatible time parser.
+ *
+ * Embulk's timestamp formats are based on Ruby's formats for historical reasons, and kept for compatibility.
+ * Embulk maintains its own implementation of Ruby-compatible time parser to be independent from JRuby.
+ *
+ * This class is intentionally package-private so that plugins do not directly depend.
+ *
+ * This class is almost reimplementation of Ruby v2.3.1's ext/date/date_strptime.c. See its COPYING for license.
+ *
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup">ext/date/date_strptime.c</a>
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/COPYING?view=markup">COPYING</a>
+ */
+class RubyTimeParser {
+    // day_names
+    private static final String[] DAY_NAMES = new String[] {
+            "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+            "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+    };
+
+    // month_names
+    private static final String[] MONTH_NAMES = new String[] {
+            "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December",
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+
+    // merid_names
+    private static final String[] MERID_NAMES = new String[] {"am", "pm", "a.m.", "p.m."};
+
+    public RubyTimeParser(final RubyTimeFormat format) {
+        this.format = format;
+    }
+
+    public RubyTimeParsed parse(final String text) {
+        return new StringParser(text).parse(this.format);
+    }
+
+    private static class StringParser {
+        /**
+         * The regular expression is reimplemented from Ruby v2.3.1's ext/date/date_strptime.c.
+         *
+         * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l571">pat_source</a>
+         */
+        private static final Pattern ZONE_PARSE_REGEX =
+                Pattern.compile("\\A("
+                                        + "(?:gmt|utc?)?[-+]\\d+(?:[,.:]\\d+(?::\\d+)?)?"
+                                        + "|(?-i:[[\\p{Alpha}].\\s]+)(?:standard|daylight)\\s+time\\b"
+                                        + "|(?-i:[[\\p{Alpha}]]+)(?:\\s+dst)?\\b"
+                                        + ")",
+                                Pattern.CASE_INSENSITIVE);
+
+        private final String text;
+
+        private int pos;
+        private boolean fail;
+
+        private StringParser(String text) {
+            this.text = text;
+
+            this.pos = 0;
+            this.fail = false;
+        }
+
+        private RubyTimeParsed parse(final RubyTimeFormat format) {
+            final RubyTimeParsed.Builder builder = TimeParsed.rubyBuilder(this.text);
+
+            for (final RubyTimeFormat.TokenWithNext tokenWithNext : format) {
+                final RubyTimeFormatToken token = tokenWithNext.getToken();
+
+                if (!token.isDirective()) {
+                    final RubyTimeFormatToken.Immediate stringToken = (RubyTimeFormatToken.Immediate) token;
+                    final String str = stringToken.getContent();
+                    for (int i = 0; i < str.length(); i++) {
+                        final char c = str.charAt(i);
+                        if (isSpace(c)) {
+                            while (!isEndOfText(text, pos) && isSpace(text.charAt(pos))) {
+                                pos++;
+                            }
+                        } else {
+                            if (isEndOfText(text, pos) || c != text.charAt(pos)) {
+                                fail = true;
+                            }
+                            pos++;
+                        }
+                    }
+                } else {
+                    switch (((RubyTimeFormatToken.Directive) token).getFormatDirective()) {
+                        // %A - The full weekday name (``Sunday'')
+                        // %a - The abbreviated name (``Sun'')
+                        case DAY_OF_WEEK_FULL_NAME:
+                        case DAY_OF_WEEK_ABBREVIATED_NAME: {
+                            final int dayIndex = findIndexInPatterns(DAY_NAMES);
+                            if (dayIndex >= 0) {
+                                builder.setDayOfWeekStartingWithSunday0(dayIndex % 7);
+                                pos += DAY_NAMES[dayIndex].length();
+                            } else {
+                                fail = true;
+                            }
+                            break;
+                        }
+                        // %B - The full month name (``January'')
+                        // %b, %h - The abbreviated month name (``Jan'')
+                        case MONTH_OF_YEAR_FULL_NAME:
+                        case MONTH_OF_YEAR_ABBREVIATED_NAME:
+                        case MONTH_OF_YEAR_ABBREVIATED_NAME_ALIAS_SMALL_H: {
+                            final int monIndex = findIndexInPatterns(MONTH_NAMES);
+                            if (monIndex >= 0) {
+                                builder.setMonthOfYear(monIndex % 12 + 1);
+                                pos += MONTH_NAMES[monIndex].length();
+                            } else {
+                                fail = true;
+                            }
+                            break;
+                        }
+                        // %C - year / 100 (round down.  20 in 2009)
+                        case CENTURY: {
+                            final long cent;
+                            if (isNumberPattern(tokenWithNext.getNextToken())) {
+                                cent = readDigits(2);
+                            } else {
+                                cent = readDigitsMax();
+                            }
+                            builder.setCentury((int) cent);
+                            break;
+                        }
+                        // %d, %Od - Day of the month, zero-padded (01..31)
+                        // %e, %Oe - Day of the month, blank-padded ( 1..31)
+                        case DAY_OF_MONTH_ZERO_PADDED:
+                        case DAY_OF_MONTH_BLANK_PADDED: {
+                            final long day;
+                            if (isBlank(text, pos)) {
+                                pos += 1;  // blank
+                                day = readDigits(1);
+                            } else {
+                                day = readDigits(2);
+                            }
+
+                            if (!validRange(day, 1, 31)) {
+                                fail = true;
+                            }
+                            builder.setDayOfMonth((int) day);
+                            break;
+                        }
+                        // %G - The week-based year
+                        case WEEK_BASED_YEAR_WITH_CENTURY: {
+                            final long year;
+                            if (isNumberPattern(tokenWithNext.getNextToken())) {
+                                year = readDigits(4);
+                            } else {
+                                year = readDigitsMax();
+                            }
+                            builder.setWeekBasedYear((int) year);
+                            break;
+                        }
+                        // %g - The last 2 digits of the week-based year (00..99)
+                        case WEEK_BASED_YEAR_WITHOUT_CENTURY: {
+                            final long v = readDigits(2);
+                            if (!validRange(v, 0, 99)) {
+                                fail = true;
+                            }
+                            builder.setWeekBasedYearWithoutCentury((int) v);
+                            break;
+                        }
+                        // %H, %OH - Hour of the day, 24-hour clock, zero-padded (00..23)
+                        // %k - Hour of the day, 24-hour clock, blank-padded ( 0..23)
+                        case HOUR_OF_DAY_ZERO_PADDED:
+                        case HOUR_OF_DAY_BLANK_PADDED: {
+                            final long hour;
+                            if (isBlank(text, pos)) {
+                                pos += 1;  // blank
+                                hour = readDigits(1);
+                            } else {
+                                hour = readDigits(2);
+                            }
+
+                            if (!validRange(hour, 0, 24)) {
+                                fail = true;
+                            }
+                            builder.setHour((int) hour);
+                            break;
+                        }
+                        // %I, %OI - Hour of the day, 12-hour clock, zero-padded (01..12)
+                        // %l - Hour of the day, 12-hour clock, blank-padded ( 1..12)
+                        case HOUR_OF_AMPM_ZERO_PADDED:
+                        case HOUR_OF_AMPM_BLANK_PADDED: {
+                            final long hour;
+                            if (isBlank(text, pos)) {
+                                pos += 1; // blank
+                                hour = readDigits(1);
+                            } else {
+                                hour = readDigits(2);
+                            }
+
+                            if (!validRange(hour, 1, 12)) {
+                                fail = true;
+                            }
+                            builder.setHour((int) hour);
+                            break;
+                        }
+                        // %j - Day of the year (001..366)
+                        case DAY_OF_YEAR: {
+                            final long day = readDigits(3);
+                            if (!validRange(day, 1, 365)) {
+                                fail = true;
+                            }
+                            builder.setDayOfYear((int) day);
+                            break;
+                        }
+                        // %L - Millisecond of the second (000..999)
+                        // %N - Fractional seconds digits, default is 9 digits (nanosecond)
+                        case MILLI_OF_SECOND:
+                        case NANO_OF_SECOND: {
+                            boolean negative = false;
+                            if (isSign(text, pos)) {
+                                negative = text.charAt(pos) == '-';
+                                pos++;
+                            }
+
+                            final long v;
+                            final int initPos = pos;
+                            if (isNumberPattern(tokenWithNext.getNextToken())) {
+                                if (((RubyTimeFormatToken.Directive) token).getFormatDirective()
+                                        == RubyTimeFormatDirective.MILLI_OF_SECOND) {
+                                    v = readDigits(3);
+                                } else {
+                                    v = readDigits(9);
+                                }
+                            } else {
+                                v = readDigitsMax();
+                            }
+
+                            builder.setNanoOfSecond(
+                                        (int) (!negative ? v : -v) * (int) Math.pow(10, 9 - (pos - initPos)));
+                            break;
+                        }
+                        // %M, %OM - Minute of the hour (00..59)
+                        case MINUTE_OF_HOUR: {
+                            final long min = readDigits(2);
+                            if (!validRange(min, 0, 59)) {
+                                fail = true;
+                            }
+                            builder.setMinuteOfHour((int) min);
+                            break;
+                        }
+                        // %m, %Om - Month of the year, zero-padded (01..12)
+                        case MONTH_OF_YEAR: {
+                            final long mon = readDigits(2);
+                            if (!validRange(mon, 1, 12)) {
+                                fail = true;
+                            }
+                            builder.setMonthOfYear((int) mon);
+                            break;
+                        }
+                        // %P - Meridian indicator, lowercase (``am'' or ``pm'')
+                        // %p - Meridian indicator, uppercase (``AM'' or ``PM'')
+                        case AMPM_OF_DAY_UPPER_CASE:
+                        case AMPM_OF_DAY_LOWER_CASE: {
+                            final int meridIndex = findIndexInPatterns(MERID_NAMES);
+                            if (meridIndex >= 0) {
+                                builder.setAmPmOfDay(meridIndex % 2 == 0 ? 0 : 12);
+                                pos += MERID_NAMES[meridIndex].length();
+                            } else {
+                                fail = true;
+                            }
+                            break;
+                        }
+                        // %Q - Number of milliseconds since 1970-01-01 00:00:00 UTC.
+                        case MILLISECOND_SINCE_EPOCH: {
+                            boolean negative = false;
+                            if (isMinus(text, pos)) {
+                                negative = true;
+                                pos++;
+                            }
+
+                            final long sec = (negative ? -readDigitsMax() : readDigitsMax());
+
+                            builder.setInstantSeconds(
+                                    Instant.ofEpochSecond(sec / 1000L, sec % 1000L * (long) Math.pow(10, 6)));
+                            break;
+                        }
+                        // %S - Second of the minute (00..59)
+                        case SECOND_OF_MINUTE: {
+                            final long sec = readDigits(2);
+                            if (!validRange(sec, 0, 60)) {
+                                fail = true;
+                            }
+                            builder.setSecondOfMinute((int) sec);
+                            break;
+                        }
+                        // %s - Number of seconds since 1970-01-01 00:00:00 UTC.
+                        case SECOND_SINCE_EPOCH: {
+                            boolean negative = false;
+                            if (isMinus(text, pos)) {
+                                negative = true;
+                                pos++;
+                            }
+
+                            final long sec = readDigitsMax();
+                            builder.setInstantSeconds(Instant.ofEpochSecond(!negative ? sec : -sec, 0));
+                            break;
+                        }
+                        // %U, %OU - Week number of the year.  The week starts with Sunday.  (00..53)
+                        // %W, %OW - Week number of the year.  The week starts with Monday.  (00..53)
+                        case WEEK_OF_YEAR_STARTING_WITH_SUNDAY:
+                        case WEEK_OF_YEAR_STARTING_WITH_MONDAY: {
+                            final long week = readDigits(2);
+                            if (!validRange(week, 0, 53)) {
+                                fail = true;
+                            }
+
+                            if (((RubyTimeFormatToken.Directive) token).getFormatDirective()
+                                    == RubyTimeFormatDirective.WEEK_OF_YEAR_STARTING_WITH_SUNDAY) {
+                                builder.setWeekOfYearStartingWithSunday((int) week);
+                            } else {
+                                builder.setWeekOfYearStartingWithMonday((int) week);
+                            }
+                            break;
+                        }
+                        // %u, %Ou - Day of the week (Monday is 1, 1..7)
+                        case DAY_OF_WEEK_STARTING_WITH_MONDAY_1: {
+                            final long day = readDigits(1);
+                            if (!validRange(day, 1, 7)) {
+                                fail = true;
+                            }
+                            builder.setDayOfWeekStartingWithMonday1((int) day);
+                            break;
+                        }
+                        // %V, %OV - Week number of the week-based year (01..53)
+                        case WEEK_OF_WEEK_BASED_YEAR: {
+                            final long week = readDigits(2);
+                            if (!validRange(week, 1, 53)) {
+                                fail = true;
+                            }
+                            builder.setWeekOfWeekBasedYear((int) week);
+                            break;
+                        }
+                        // %w - Day of the week (Sunday is 0, 0..6)
+                        case DAY_OF_WEEK_STARTING_WITH_SUNDAY_0: {
+                            final long day = readDigits(1);
+                            if (!validRange(day, 0, 6)) {
+                                fail = true;
+                            }
+                            builder.setDayOfWeekStartingWithSunday0((int) day);
+                            break;
+                        }
+                        // %Y, %EY - Year with century (can be negative, 4 digits at least)
+                        //           -0001, 0000, 1995, 2009, 14292, etc.
+                        case YEAR_WITH_CENTURY: {
+                            boolean negative = false;
+                            if (isSign(text, pos)) {
+                                negative = text.charAt(pos) == '-';
+                                pos++;
+                            }
+
+                            final long year;
+                            if (isNumberPattern(tokenWithNext.getNextToken())) {
+                                year = readDigits(4);
+                            } else {
+                                year = readDigitsMax();
+                            }
+
+                            builder.setYear((int) (!negative ? year : -year));
+                            break;
+                        }
+                        // %y, %Ey, %Oy - year % 100 (00..99)
+                        case YEAR_WITHOUT_CENTURY: {
+                            final long y = readDigits(2);
+                            if (!validRange(y, 0, 99)) {
+                                fail = true;
+                            }
+                            builder.setYearWithoutCentury((int) y);
+                            break;
+                        }
+                        // %Z - Time zone abbreviation name
+                        // %z - Time zone as hour and minute offset from UTC (e.g. +0900)
+                        //      %:z - hour and minute offset from UTC with a colon (e.g. +09:00)
+                        //      %::z - hour, minute and second offset from UTC (e.g. +09:00:00)
+                        //      %:::z - hour, minute and second offset from UTC (e.g. +09, +09:30, +09:30:30)
+                        case TIME_ZONE_NAME:
+                        case TIME_OFFSET: {
+                            if (isEndOfText(text, pos)) {
+                                fail = true;
+                                break;
+                            }
+
+                            final Matcher m = ZONE_PARSE_REGEX.matcher(text.substring(pos));
+                            if (m.find()) {
+                                // zone
+                                String zone = text.substring(pos, pos + m.end());
+                                builder.setTimeOffset(zone);
+                                pos += zone.length();
+                            } else {
+                                fail = true;
+                            }
+                            break;
+                        }
+                        default:  // Do nothing, and just pass through.
+                    }
+                }
+            }
+
+            if (fail) {
+                return null;
+            }
+
+            if (text.length() > pos) {
+                builder.setLeftover(text.substring(pos, text.length()));
+            }
+
+            return builder.build();
+        }
+
+        /**
+         * The method is reimplemented based on read_digits from Ruby v2.3.1's ext/date/date_strptime.c.
+         *
+         * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l77">read_digits</a>
+         */
+        private long readDigits(final int len) {
+            char c;
+            long v = 0;
+            final int initPos = pos;
+
+            for (int i = 0; i < len; i++) {
+                if (isEndOfText(text, pos)) {
+                    break;
+                }
+
+                c = text.charAt(pos);
+                if (!isDigit(c)) {
+                    break;
+                } else {
+                    v = v * 10 + toInt(c);
+                }
+                pos += 1;
+            }
+
+            if (pos == initPos) {
+                fail = true;
+            }
+
+            return v;
+        }
+
+        /**
+         * The method is reimplemented based on READ_DIGITS_MAX from Ruby v2.3.1's ext/date/date_strptime.c.
+         *
+         * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l137">READ_DIGITS_MAX</a>
+         */
+        private long readDigitsMax() {
+            return readDigits(Integer.MAX_VALUE);
+        }
+
+        /**
+         * Returns -1 if text doesn't match with patterns.
+         */
+        private int findIndexInPatterns(final String[] patterns) {
+            if (isEndOfText(text, pos)) {
+                return -1;
+            }
+
+            for (int i = 0; i < patterns.length; i++) {
+                final String pattern = patterns[i];
+                final int len = pattern.length();
+                if (!isEndOfText(text, pos + len - 1)
+                        && pattern.equalsIgnoreCase(text.substring(pos, pos + len))) { // strncasecmp
+                    return i;
+                }
+            }
+
+            return -1; // text doesn't match at any patterns.
+        }
+
+        /**
+         * The method is reimplemented based on num_pattern_p from Ruby v2.3.1's ext/date/date_strptime.c.
+         *
+         * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l58">num_pattern_p</a>
+         */
+        private static boolean isNumberPattern(final RubyTimeFormatToken token) {
+            if (token == null) {
+                return false;
+            } else if ((!token.isDirective()) && isDigit(((RubyTimeFormatToken.Immediate) token).getContent().charAt(0))) {
+                return true;
+            } else if (token.isDirective() && ((RubyTimeFormatToken.Directive) token).getFormatDirective().isNumeric()) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * The method is reimplemented based on valid_range_p from Ruby v2.3.1's ext/date/date_strptime.c.
+         *
+         * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l139">valid_range_p</a>
+         */
+        private static boolean validRange(long v, int lower, int upper) {
+            return lower <= v && v <= upper;
+        }
+
+        private static boolean isSpace(char c) {
+            return c == ' ' || c == '\t' || c == '\n' || c == '\u000b' || c == '\f' || c == '\r';
+        }
+
+        private static boolean isDigit(char c) {
+            return '0' <= c && c <= '9';
+        }
+
+        private static boolean isEndOfText(String text, int pos) {
+            return pos >= text.length();
+        }
+
+        private static boolean isSign(String text, int pos) {
+            return !isEndOfText(text, pos) && (text.charAt(pos) == '+' || text.charAt(pos) == '-');
+        }
+
+        private static boolean isMinus(String text, int pos) {
+            return !isEndOfText(text, pos) && text.charAt(pos) == '-';
+        }
+
+        private static boolean isBlank(String text, int pos) {
+            return !isEndOfText(text, pos) && text.charAt(pos) == ' ';
+        }
+
+        private static int toInt(char c) {
+            return c - '0';
+        }
+    }
+
+    private final RubyTimeFormat format;
+}

--- a/src/main/java/org/embulk/spi/time/RubyTimeZoneTab.java
+++ b/src/main/java/org/embulk/spi/time/RubyTimeZoneTab.java
@@ -1,0 +1,460 @@
+package org.embulk.spi.time;
+
+/**
+ * RubyTimeZoneTab lists from Ruby-compatible timezone names and their time offsets.
+ *
+ * Embulk's timestamp formats are based on Ruby's formats for historical reasons, and kept for compatibility.
+ * Embulk maintains its own implementation of Ruby-compatible time parser to be independent from JRuby.
+ *
+ * This class is intentionally package-private so that plugins do not directly depend.
+ *
+ * This class is almost reimplementation of Ruby v2.3.1's ext/date/date_parse.c. See its COPYING for license.
+ *
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_parse.c?view=markup">ext/date/date_parse.c</a>
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/COPYING?view=markup">COPYING</a>
+ *
+ * This class is contributed to the JRuby project before it is refactored on the Embulk side.
+ *
+ * @see <a href="https://github.com/jruby/jruby/pull/4635">Implement RubyDateParser in Java by muga - Pull Request #4635 - jruby/jruby</a>
+ */
+class RubyTimeZoneTab {
+    // Ported zones_source in ext/date/date_parse.c
+    private static int getOffsetFromZonesSource(String z) {
+        switch (z) {
+            case "ut":
+                return 0 * 3600;
+            case "gmt":
+                return 0 * 3600;
+            case "est":
+                return -5 * 3600;
+            case "edt":
+                return -4 * 3600;
+            case "cst":
+                return -6 * 3600;
+            case "cdt":
+                return -5 * 3600;
+            case "mst":
+                return -7 * 3600;
+            case "mdt":
+                return -6 * 3600;
+            case "pst":
+                return -8 * 3600;
+            case "pdt":
+                return -7 * 3600;
+            case "a":
+                return 1 * 3600;
+            case "b":
+                return 2 * 3600;
+            case "c":
+                return 3 * 3600;
+            case "d":
+                return 4 * 3600;
+            case "e":
+                return 5 * 3600;
+            case "f":
+                return 6 * 3600;
+            case "g":
+                return 7 * 3600;
+            case "h":
+                return 8 * 3600;
+            case "i":
+                return 9 * 3600;
+            case "k":
+                return 10 * 3600;
+            case "l":
+                return 11 * 3600;
+            case "m":
+                return 12 * 3600;
+            case "n":
+                return -1 * 3600;
+            case "o":
+                return -2 * 3600;
+            case "p":
+                return -3 * 3600;
+            case "q":
+                return -4 * 3600;
+            case "r":
+                return -5 * 3600;
+            case "s":
+                return -6 * 3600;
+            case "t":
+                return -7 * 3600;
+            case "u":
+                return -8 * 3600;
+            case "v":
+                return -9 * 3600;
+            case "w":
+                return -10 * 3600;
+            case "x":
+                return -11 * 3600;
+            case "y":
+                return -12 * 3600;
+            case "z":
+                return 0 * 3600;
+            case "utc":
+                return 0 * 3600;
+            case "wet":
+                return 0 * 3600;
+            case "at":
+                return -2 * 3600;
+            case "brst":
+                return -2 * 3600;
+            case "ndt":
+                return -(2 * 3600 + 1800);
+            case "art":
+                return -3 * 3600;
+            case "adt":
+                return -3 * 3600;
+            case "brt":
+                return -3 * 3600;
+            case "clst":
+                return -3 * 3600;
+            case "nst":
+                return -(3 * 3600 + 1800);
+            case "ast":
+                return -4 * 3600;
+            case "clt":
+                return -4 * 3600;
+            case "akdt":
+                return -8 * 3600;
+            case "ydt":
+                return -8 * 3600;
+            case "akst":
+                return -9 * 3600;
+            case "hadt":
+                return -9 * 3600;
+            case "hdt":
+                return -9 * 3600;
+            case "yst":
+                return -9 * 3600;
+            case "ahst":
+                return -10 * 3600;
+            case "cat":
+                return -10 * 3600;
+            case "hast":
+                return -10 * 3600;
+            case "hst":
+                return -10 * 3600;
+            case "nt":
+                return -11 * 3600;
+            case "idlw":
+                return -12 * 3600;
+            case "bst":
+                return 1 * 3600;
+            case "cet":
+                return 1 * 3600;
+            case "fwt":
+                return 1 * 3600;
+            case "met":
+                return 1 * 3600;
+            case "mewt":
+                return 1 * 3600;
+            case "mez":
+                return 1 * 3600;
+            case "swt":
+                return 1 * 3600;
+            case "wat":
+                return 1 * 3600;
+            case "west":
+                return 1 * 3600;
+            case "cest":
+                return 2 * 3600;
+            case "eet":
+                return 2 * 3600;
+            case "fst":
+                return 2 * 3600;
+            case "mest":
+                return 2 * 3600;
+            case "mesz":
+                return 2 * 3600;
+            case "sast":
+                return 2 * 3600;
+            case "sst":
+                return 2 * 3600;
+            case "bt":
+                return 3 * 3600;
+            case "eat":
+                return 3 * 3600;
+            case "eest":
+                return 3 * 3600;
+            case "msk":
+                return 3 * 3600;
+            case "msd":
+                return 4 * 3600;
+            case "zp4":
+                return 4 * 3600;
+            case "zp5":
+                return 5 * 3600;
+            case "ist":
+                return 5 * 3600 + 1800;
+            case "zp6":
+                return 6 * 3600;
+            case "wast":
+                return 7 * 3600;
+            case "cct":
+                return 8 * 3600;
+            case "sgt":
+                return 8 * 3600;
+            case "wadt":
+                return 8 * 3600;
+            case "jst":
+                return 9 * 3600;
+            case "kst":
+                return 9 * 3600;
+            case "east":
+                return 10 * 3600;
+            case "gst":
+                return 10 * 3600;
+            case "eadt":
+                return 11 * 3600;
+            case "idle":
+                return 12 * 3600;
+            case "nzst":
+                return 12 * 3600;
+            case "nzt":
+                return 12 * 3600;
+            case "nzdt":
+                return 13 * 3600;
+            case "afghanistan":
+                return 16200;
+            case "alaskan":
+                return -32400;
+            case "arab":
+                return 10800;
+            case "arabian":
+                return 14400;
+            case "arabic":
+                return 10800;
+            case "atlantic":
+                return -14400;
+            case "aus central":
+                return 34200;
+            case "aus eastern":
+                return 36000;
+            case "azores":
+                return -3600;
+            case "canada central":
+                return -21600;
+            case "cape verde":
+                return -3600;
+            case "caucasus":
+                return 14400;
+            case "cen. australia":
+                return 34200;
+            case "central america":
+                return -21600;
+            case "central asia":
+                return 21600;
+            case "central europe":
+                return 3600;
+            case "central european":
+                return 3600;
+            case "central pacific":
+                return 39600;
+            case "central":
+                return -21600;
+            case "china":
+                return 28800;
+            case "dateline":
+                return -43200;
+            case "e. africa":
+                return 10800;
+            case "e. australia":
+                return 36000;
+            case "e. europe":
+                return 7200;
+            case "e. south america":
+                return -10800;
+            case "eastern":
+                return -18000;
+            case "egypt":
+                return 7200;
+            case "ekaterinburg":
+                return 18000;
+            case "fiji":
+                return 43200;
+            case "fle":
+                return 7200;
+            case "greenland":
+                return -10800;
+            case "greenwich":
+                return 0;
+            case "gtb":
+                return 7200;
+            case "hawaiian":
+                return -36000;
+            case "india":
+                return 19800;
+            case "iran":
+                return 12600;
+            case "jerusalem":
+                return 7200;
+            case "korea":
+                return 32400;
+            case "mexico":
+                return -21600;
+            case "mid-atlantic":
+                return -7200;
+            case "mountain":
+                return -25200;
+            case "myanmar":
+                return 23400;
+            case "n. central asia":
+                return 21600;
+            case "nepal":
+                return 20700;
+            case "new zealand":
+                return 43200;
+            case "newfoundland":
+                return -12600;
+            case "north asia east":
+                return 28800;
+            case "north asia":
+                return 25200;
+            case "pacific sa":
+                return -14400;
+            case "pacific":
+                return -28800;
+            case "romance":
+                return 3600;
+            case "russian":
+                return 10800;
+            case "sa eastern":
+                return -10800;
+            case "sa pacific":
+                return -18000;
+            case "sa western":
+                return -14400;
+            case "samoa":
+                return -39600;
+            case "se asia":
+                return 25200;
+            case "malay peninsula":
+                return 28800;
+            case "south africa":
+                return 7200;
+            case "sri lanka":
+                return 21600;
+            case "taipei":
+                return 28800;
+            case "tasmania":
+                return 36000;
+            case "tokyo":
+                return 32400;
+            case "tonga":
+                return 46800;
+            case "us eastern":
+                return -18000;
+            case "us mountain":
+                return -25200;
+            case "vladivostok":
+                return 36000;
+            case "w. australia":
+                return 28800;
+            case "w. central africa":
+                return 3600;
+            case "w. europe":
+                return 3600;
+            case "west asia":
+                return 18000;
+            case "west pacific":
+                return 36000;
+            case "yakutsk":
+                return 32400;
+            default:
+                return Integer.MIN_VALUE;
+        }
+    }
+
+    // Ported date_zone_to_diff in ext/date/date_parse.c
+    public static int dateZoneToDiff(String zone) {
+        String z = zone.toLowerCase();
+
+        final boolean dst;
+        if (z.endsWith(" daylight time")) {
+            z = z.substring(0, z.length() - " daylight time".length());
+            dst = true;
+        } else if (z.endsWith(" standard time")) {
+            z = z.substring(0, z.length() - " standard time".length());
+            dst = false;
+        } else if (z.endsWith(" dst")) {
+            z = z.substring(0, z.length() - " dst".length());
+            dst = true;
+        } else {
+            dst = false;
+        }
+
+        int offsetFromZonesSource;
+        if ((offsetFromZonesSource = getOffsetFromZonesSource(z)) != Integer.MIN_VALUE) {
+            if (dst) {
+                offsetFromZonesSource += 3600;
+            }
+            return offsetFromZonesSource;
+        }
+
+        if (z.startsWith("gmt") || z.startsWith("utc")) {
+            z = z.substring(3, z.length()); // remove "gmt" or "utc"
+        }
+
+        final boolean sign;
+        if (z.charAt(0) == '+') {
+            sign = true;
+        } else if (z.charAt(0) == '-') {
+            sign = false;
+        } else {
+            // if z doesn't start with "+" or "-", invalid
+            return Integer.MIN_VALUE;
+        }
+        z = z.substring(1);
+
+        int hour = 0;
+        int min = 0;
+        int sec = 0;
+        if (z.contains(":")) {
+            final String[] splited = z.split(":");
+            if (splited.length == 2) {
+                hour = Integer.parseInt(splited[0]);
+                min = Integer.parseInt(splited[1]);
+            } else {
+                hour = Integer.parseInt(splited[0]);
+                min = Integer.parseInt(splited[1]);
+                sec = Integer.parseInt(splited[2]);
+            }
+
+        } else if (z.contains(",") || z.contains(".")) {
+            // TODO min = Rational(fr.to_i, 10**fr.size) * 60
+            String[] splited = z.split("[\\.,]");
+            hour = Integer.parseInt(splited[0]);
+            min = (int) (Integer.parseInt(splited[1]) * 60 / Math.pow(10, splited[1].length()));
+
+        } else {
+            final int len = z.length();
+            if (len % 2 != 0) {
+                if (len >= 1) {
+                    hour = Integer.parseInt(z.substring(0, 1));
+                }
+                if (len >= 3) {
+                    min = Integer.parseInt(z.substring(1, 3));
+                }
+                if (len >= 5) {
+                    sec = Integer.parseInt(z.substring(3, 5));
+                }
+            } else {
+                if (len >= 2) {
+                    hour = Integer.parseInt(z.substring(0, 2));
+                }
+                if (len >= 4) {
+                    min = Integer.parseInt(z.substring(2, 4));
+                }
+                if (len >= 6) {
+                    sec = Integer.parseInt(z.substring(4, 6));
+                }
+            }
+        }
+
+        final int offset = hour * 3600 + min * 60 + sec;
+        return sign ? offset : -offset;
+    }
+
+    private RubyTimeZoneTab() {}
+}

--- a/src/main/java/org/embulk/spi/time/TimeParsed.java
+++ b/src/main/java/org/embulk/spi/time/TimeParsed.java
@@ -1,0 +1,21 @@
+package org.embulk.spi.time;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+/**
+ * TimeParsed is a container of date/time information parsed from a string.
+ */
+abstract class TimeParsed {  // to extend java.time.temporal.TemporalAccessor in Java 8
+    static RubyTimeParsed.Builder rubyBuilder(final String originalString) {
+        return new RubyTimeParsed.Builder(originalString);
+    }
+
+    abstract Instant toInstant(final ZoneOffset defaultZoneOffset);
+
+    abstract Instant toInstant(final int defaultYear,
+                               final int defaultMonthOfYear,
+                               final int defaultDayOfMonth,
+                               final ZoneId defaultZoneId);
+}

--- a/src/main/java/org/embulk/spi/time/TimeZoneIds.java
+++ b/src/main/java/org/embulk/spi/time/TimeZoneIds.java
@@ -1,0 +1,270 @@
+package org.embulk.spi.time;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * TimeZoneIds is a utility class for operating with time zones.
+ *
+ * This class is public only to be called from DynamicColumnSetterFactory and DynamicPageBuilder.
+ * It is not guaranteed to use this class from plugins. This class may be moved, renamed, or removed.
+ *
+ * A part of this class is reimplementation of Ruby v2.3.1's lib/time.rb. See its COPYING for license.
+ *
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup">lib/time.rb</a>
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/COPYING?view=markup">COPYING</a>
+ */
+public class TimeZoneIds {
+    private TimeZoneIds() {
+        // No instantiation.
+    }
+
+    /**
+     * Converts org.joda.time.DateTimeZone to its corresponding java.time.ZoneID.
+     */
+    public static ZoneId convertJodaDateTimeZoneToZoneId(final org.joda.time.DateTimeZone jodaDateTimeZone) {
+        return ZoneId.of(jodaDateTimeZone.getID(), ALIAS_ZONE_IDS_FOR_LEGACY);
+    }
+
+    /**
+     * Converts java.time.ZoneOffset to its corresponding org.joda.time.DateTimeZone.
+     */
+    public static org.joda.time.DateTimeZone convertZoneOffsetToJodaDateTimeZone(final ZoneOffset zoneOffset) {
+        return org.joda.time.DateTimeZone.forOffsetMillis(zoneOffset.getTotalSeconds() * 1000);
+    }
+
+    /**
+     * Parses a time zone ID to java.time.ZoneOffset basically in the same rule with Ruby v2.3.1's Time.strptime.
+     *
+     * The only difference from Ruby v2.3.1's Time.strptime is that it does not consider local time zone.
+     * If the given zone is neither numerical nor predefined textual time zones, it returns defaultZoneOffset then.
+     *
+     * The method is reimplemented based on zone_offset from Ruby v2.3.1's lib/time.rb.
+     *
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l134">zone_offset</a>
+     */
+    public static ZoneOffset parseRubyTimeZoneOffset(final String zoneId, final ZoneOffset defaultZoneOffset) {
+        if (zoneId == null) {
+            return defaultZoneOffset;
+        }
+
+        if (zoneId.charAt(0) == '+' || zoneId.charAt(0) == '-') {
+            if (RUBY_TIME_ZONE_OFFSET_PATTERN_HH_MM.matcher(zoneId).matches()
+                    || RUBY_TIME_ZONE_OFFSET_PATTERN_HH.matcher(zoneId).matches()) {
+                return ZoneOffset.of(zoneId);
+            }
+            return defaultZoneOffset;
+        }
+
+        final ZoneOffset zoneOffset = RUBY_TIME_ZONE_OFFSET_IDS.get(zoneId.toUpperCase(Locale.ENGLISH));
+        if (zoneOffset != null) {
+            return zoneOffset;
+        }
+        return defaultZoneOffset;
+    }
+
+    /**
+     * Parses time zone ID to java.time.ZoneId as compatible with the time zone parser of Embulk v0.8 as possible.
+     *
+     * It recognizes time zone IDs in the following priority.
+     *
+     * <ol>
+     * <li>"Z" is always recognized as UTC in the first priority.
+     * <li>If the ID is "EST", "EDT", "CST", "CDT", "MST", "MDT", "PST", or "PDT", parsed by ZoneId.of with alias.
+     * <li>If the ID is "HST", "ROC", or recognized by ZoneId.of, it is parsed by ZoneId.of with alias.
+     * <li>Otherwise, the zone ID is recognized by Ruby-compatible zone tab.
+     * <li>If none of the above does not recognize the zone ID, it returns null.
+     * </ol>
+     *
+     * Its time offset transitions in each time zone may be different from the time zone parser of Embulk v0.8,
+     * but the difference is from their base time zone (tz) database. The difference is ignorable as time zone
+     * database is continuously updated anyway.
+     */
+    public static ZoneId parseZoneIdWithJodaAndRubyZoneTab(final String zoneId) {
+        if (zoneId.equals("Z")) {
+            return ZoneOffset.UTC;
+        }
+
+        try {
+            return ZoneId.of(zoneId, ALIAS_ZONE_IDS_FOR_LEGACY);  // Is is never null unless Exception is thrown.
+        } catch (DateTimeException ex) {
+            final int rubyStyleTimeOffsetInSecond = RubyTimeZoneTab.dateZoneToDiff(zoneId);
+            if (rubyStyleTimeOffsetInSecond != Integer.MIN_VALUE) {
+                return ZoneOffset.ofTotalSeconds(rubyStyleTimeOffsetInSecond);
+            }
+            return null;
+        }
+    }
+
+    public static org.joda.time.DateTimeZone parseJodaDateTimeZone(final String timeZoneName) {
+        org.joda.time.DateTimeZone jodaDateTimeZoneTemporary = null;
+        try {
+            // Use TimeZone#forID, not TimeZone#getTimeZone.
+            // Because getTimeZone returns GMT even if given timezone id is not found.
+            jodaDateTimeZoneTemporary = org.joda.time.DateTimeZone.forID(timeZoneName);
+        } catch (IllegalArgumentException ex) {
+            jodaDateTimeZoneTemporary = null;
+        }
+        final org.joda.time.DateTimeZone jodaDateTimeZone = jodaDateTimeZoneTemporary;
+
+        // Embulk has accepted to parse Joda-Time's time zone IDs in Timestamps since v0.2.0
+        // although the formats are based on Ruby's strptime. Joda-Time's time zone IDs are
+        // continuously to be accepted with higher priority than Ruby's time zone IDs.
+        if (jodaDateTimeZone != null && (timeZoneName.startsWith("+") || timeZoneName.startsWith("-"))) {
+            return jodaDateTimeZone;
+
+        } else if (timeZoneName.equals("Z")) {
+            return org.joda.time.DateTimeZone.UTC;
+
+        } else {
+            try {
+                // DateTimeFormat.forPattern("z").parseMillis(s) is incorrect, but kept for compatibility as of now.
+                //
+                // The offset of PDT (Pacific Daylight Time) should be -07:00.
+                // DateTimeFormat.forPattern("z").parseMillis("PDT") however returns 8 hours (-08:00).
+                // DateTimeFormat.forPattern("z").parseMillis("PDT") == 28800000
+                // https://github.com/JodaOrg/joda-time/blob/v2.9.2/src/main/java/org/joda/time/DateTimeUtils.java#L446
+                //
+                // Embulk has used it to parse time zones for a very long time since it was v0.1.
+                // https://github.com/embulk/embulk/commit/b97954a5c78397e1269bbb6979d6225dfceb4e05
+                //
+                // It is kept as -08:00 for compatibility as of now.
+                //
+                // TODO: Make time zone parsing consistent.
+                // @see <a href="https://github.com/embulk/embulk/issues/860">https://github.com/embulk/embulk/issues/860</a>
+                int rawOffset = (int) org.joda.time.format.DateTimeFormat.forPattern("z").parseMillis(timeZoneName);
+                if (rawOffset == 0) {
+                    return org.joda.time.DateTimeZone.UTC;
+                }
+                int offset = rawOffset / -1000;
+                int h = offset / 3600;
+                int m = offset % 3600;
+                return org.joda.time.DateTimeZone.forOffsetHoursMinutes(h, m);
+            } catch (IllegalArgumentException ex) {
+                // parseMillis failed
+            }
+
+            if (jodaDateTimeZone != null && JODA_TIME_ZONES.contains(timeZoneName)) {
+                return jodaDateTimeZone;
+            }
+
+            // Parsing Ruby-style time zones in lower priority than Joda-Time because
+            // TimestampParser has parsed time zones with Joda-Time for a long time
+            // since ancient. The behavior is kept for compatibility.
+            //
+            // The following time zone IDs are duplicated in Ruby and Joda-Time 2.9.2
+            // while Ruby does not care summer time and Joda-Time cares summer time.
+            // "CET", "EET", "Egypt", "Iran", "MET", "WET"
+            //
+            // Some zone IDs (ex. "PDT") are parsed by DateTimeFormat#parseMillis as shown above.
+            final int rubyStyleTimeOffsetInSecond = RubyTimeZoneTab.dateZoneToDiff(timeZoneName);
+            if (rubyStyleTimeOffsetInSecond != Integer.MIN_VALUE) {
+                return org.joda.time.DateTimeZone.forOffsetMillis(rubyStyleTimeOffsetInSecond * 1000);
+            }
+
+            return null;
+        }
+    }
+
+    static {
+        final HashMap<String, String> aliasZoneIdsForLegacyParser = new HashMap<>();
+        // Embulk's legacy TimestampParser has recognized "EST", "EDT", "CST", "CDT", "MST", "MDT", "PST", and "PDT"
+        // with org.joda.time.format.DateTimeFormat.forPattern("z").parseMillis(). They have not been recognized
+        // by org.joda.time.DateTimeZone.forID(), nor listed in org.joda.time.DateTimeZone.getAvailableIDs().
+        //
+        // These short time zone IDs have not been recognized in a "correct" way in Embulk's legacy TimestampParser,
+        // though. For example, "PDT" should be -07:00 as it is daylight saving time. But, "PDT" and "PST" are both
+        // recognized as -08:00 in Embulk's legacy TimestampParser.
+        //
+        // It has been because Embulk has used org.joda.time.format.DateTimeFormat.forPattern("z").parseMillis().
+        // "PDT" is recognized as "America/Los_Angeles" in Joda-Time, which is a "not fixed" time zone.
+        // https://github.com/JodaOrg/joda-time/blob/v2.9.2/src/main/java/org/joda/time/DateTimeUtils.java#L446
+        // http://www.joda.org/joda-time/apidocs/org/joda/time/DateTimeUtils.html#getDefaultTimeZoneNames--
+        //
+        // "2017-02-20 America/Los_Angeles" is in -08:00 in Joda-Time. "2017-08-20 America/Los_Angeles" is in -7:00.
+        // org.joda.time.format.DateTimeFormat.forPattern("z").parseMillis("America/Los_Angeles") is, however, always
+        // -08:00 since it does not have the date.
+        //
+        // This set of aliases emulates org.joda.time.format.DateTimeFormat.forPattern("z").parseMillis() here
+        // for compatibility. Embulk has used it to parse time zones for a very long time since Embulk v0.1.
+        // https://github.com/embulk/embulk/commit/b97954a5c78397e1269bbb6979d6225dfceb4e05
+        // https://github.com/embulk/embulk/issues/860
+        aliasZoneIdsForLegacyParser.put("EST", "-05:00");
+        aliasZoneIdsForLegacyParser.put("EDT", "-05:00");
+        aliasZoneIdsForLegacyParser.put("CST", "-06:00");
+        aliasZoneIdsForLegacyParser.put("CDT", "-06:00");
+        aliasZoneIdsForLegacyParser.put("MST", "-07:00");
+        aliasZoneIdsForLegacyParser.put("MDT", "-07:00");
+        aliasZoneIdsForLegacyParser.put("PST", "-08:00");
+        aliasZoneIdsForLegacyParser.put("PDT", "-08:00");
+
+        // Short time zone IDs "EST", "HST", "MST", and "ROC" are recognized by org.joda.time.DateTimeZone.forID(),
+        // while they are not recognized by java.time.ZoneId.of(). "EST" and "MST" are covered by the aliaes above
+        // in higher priority. "HST" and "ROC" should be covered in addition.
+        // http://joda-time.sourceforge.net/timezones.html
+        aliasZoneIdsForLegacyParser.put("HST", "-10:00");
+        aliasZoneIdsForLegacyParser.put("ROC", "Asia/Taipei");
+
+        ALIAS_ZONE_IDS_FOR_LEGACY = Collections.unmodifiableMap(aliasZoneIdsForLegacyParser);
+
+        final HashMap<String, ZoneOffset> rubyTimeZoneOffsetIds = new HashMap<>();
+        rubyTimeZoneOffsetIds.put("UTC", ZoneOffset.UTC);
+        // ISO 8601
+        rubyTimeZoneOffsetIds.put("Z", ZoneOffset.UTC);
+        // RFC 822
+        rubyTimeZoneOffsetIds.put("UT", ZoneOffset.UTC);
+        rubyTimeZoneOffsetIds.put("GMT", ZoneOffset.UTC);
+        rubyTimeZoneOffsetIds.put("EST", ZoneOffset.ofHours(-5));
+        rubyTimeZoneOffsetIds.put("EDT", ZoneOffset.ofHours(-4));
+        rubyTimeZoneOffsetIds.put("CST", ZoneOffset.ofHours(-6));
+        rubyTimeZoneOffsetIds.put("CDT", ZoneOffset.ofHours(-5));
+        rubyTimeZoneOffsetIds.put("MST", ZoneOffset.ofHours(-7));
+        rubyTimeZoneOffsetIds.put("MDT", ZoneOffset.ofHours(-6));
+        rubyTimeZoneOffsetIds.put("PST", ZoneOffset.ofHours(-8));
+        rubyTimeZoneOffsetIds.put("PDT", ZoneOffset.ofHours(-7));
+        // Following definition of military zones is original one.
+        // See RFC 1123 and RFC 2822 for the error in RFC 822.
+        rubyTimeZoneOffsetIds.put("A", ZoneOffset.ofHours(+1));
+        rubyTimeZoneOffsetIds.put("B", ZoneOffset.ofHours(+2));
+        rubyTimeZoneOffsetIds.put("C", ZoneOffset.ofHours(+3));
+        rubyTimeZoneOffsetIds.put("D", ZoneOffset.ofHours(+4));
+        rubyTimeZoneOffsetIds.put("E", ZoneOffset.ofHours(+5));
+        rubyTimeZoneOffsetIds.put("F", ZoneOffset.ofHours(+6));
+        rubyTimeZoneOffsetIds.put("G", ZoneOffset.ofHours(+7));
+        rubyTimeZoneOffsetIds.put("H", ZoneOffset.ofHours(+8));
+        rubyTimeZoneOffsetIds.put("I", ZoneOffset.ofHours(+9));
+        rubyTimeZoneOffsetIds.put("K", ZoneOffset.ofHours(+10));
+        rubyTimeZoneOffsetIds.put("L", ZoneOffset.ofHours(+11));
+        rubyTimeZoneOffsetIds.put("M", ZoneOffset.ofHours(+12));
+        rubyTimeZoneOffsetIds.put("N", ZoneOffset.ofHours(-1));
+        rubyTimeZoneOffsetIds.put("O", ZoneOffset.ofHours(-2));
+        rubyTimeZoneOffsetIds.put("P", ZoneOffset.ofHours(-3));
+        rubyTimeZoneOffsetIds.put("Q", ZoneOffset.ofHours(-4));
+        rubyTimeZoneOffsetIds.put("R", ZoneOffset.ofHours(-5));
+        rubyTimeZoneOffsetIds.put("S", ZoneOffset.ofHours(-6));
+        rubyTimeZoneOffsetIds.put("T", ZoneOffset.ofHours(-7));
+        rubyTimeZoneOffsetIds.put("U", ZoneOffset.ofHours(-8));
+        rubyTimeZoneOffsetIds.put("V", ZoneOffset.ofHours(-9));
+        rubyTimeZoneOffsetIds.put("W", ZoneOffset.ofHours(-10));
+        rubyTimeZoneOffsetIds.put("X", ZoneOffset.ofHours(-11));
+        rubyTimeZoneOffsetIds.put("Y", ZoneOffset.ofHours(-12));
+        RUBY_TIME_ZONE_OFFSET_IDS = Collections.unmodifiableMap(rubyTimeZoneOffsetIds);
+    }
+
+    static final Map<String, String> ALIAS_ZONE_IDS_FOR_LEGACY;
+
+    private static final Set<String> JODA_TIME_ZONES =
+            Collections.unmodifiableSet(org.joda.time.DateTimeZone.getAvailableIDs());
+
+    private static final Pattern RUBY_TIME_ZONE_OFFSET_PATTERN_HH_MM = Pattern.compile("^[+-]\\d\\d:?\\d\\d$");
+    private static final Pattern RUBY_TIME_ZONE_OFFSET_PATTERN_HH = Pattern.compile("^[+-]\\d\\d$");
+
+    private static final Map<String, ZoneOffset> RUBY_TIME_ZONE_OFFSET_IDS;
+}

--- a/src/main/java/org/embulk/spi/time/TimestampParseException.java
+++ b/src/main/java/org/embulk/spi/time/TimestampParseException.java
@@ -1,0 +1,17 @@
+package org.embulk.spi.time;
+
+import org.embulk.spi.DataException;
+
+public class TimestampParseException extends DataException {
+    public TimestampParseException(String message) {
+        super(message);
+    }
+
+    public TimestampParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TimestampParseException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/org/embulk/spi/time/TestRubyTimeFormat.java
+++ b/src/test/java/org/embulk/spi/time/TestRubyTimeFormat.java
@@ -1,0 +1,372 @@
+package org.embulk.spi.time;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * TestRubyTimeFormat tests org.embulk.spi.time.RubyTimeFormat.
+ */
+public class TestRubyTimeFormat {
+    @Test
+    public void testEmpty() {
+        testFormat("");
+    }
+
+    @Test
+    public void testSingles() {
+        testFormat("%Y", RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens());
+        testFormat("%C", RubyTimeFormatDirective.CENTURY.toTokens());
+        testFormat("%y", RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+
+        testFormat("%m", RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens());
+        testFormat("%B", RubyTimeFormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens());
+        testFormat("%b", RubyTimeFormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens());
+        testFormat("%h", RubyTimeFormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME_ALIAS_SMALL_H.toTokens());
+
+        testFormat("%d", RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
+        testFormat("%e", RubyTimeFormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens());
+
+        testFormat("%j", RubyTimeFormatDirective.DAY_OF_YEAR.toTokens());
+
+        testFormat("%H", RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens());
+        testFormat("%k", RubyTimeFormatDirective.HOUR_OF_DAY_BLANK_PADDED.toTokens());
+        testFormat("%I", RubyTimeFormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens());
+        testFormat("%l", RubyTimeFormatDirective.HOUR_OF_AMPM_BLANK_PADDED.toTokens());
+        testFormat("%P", RubyTimeFormatDirective.AMPM_OF_DAY_LOWER_CASE.toTokens());
+        testFormat("%p", RubyTimeFormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens());
+
+        testFormat("%M", RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens());
+
+        testFormat("%S", RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens());
+
+        testFormat("%L", RubyTimeFormatDirective.MILLI_OF_SECOND.toTokens());
+        testFormat("%N", RubyTimeFormatDirective.NANO_OF_SECOND.toTokens());
+
+        testFormat("%z", RubyTimeFormatDirective.TIME_OFFSET.toTokens());
+        testFormat("%Z", RubyTimeFormatDirective.TIME_ZONE_NAME.toTokens());
+
+        testFormat("%A", RubyTimeFormatDirective.DAY_OF_WEEK_FULL_NAME.toTokens());
+        testFormat("%a", RubyTimeFormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens());
+        testFormat("%u", RubyTimeFormatDirective.DAY_OF_WEEK_STARTING_WITH_MONDAY_1.toTokens());
+        testFormat("%w", RubyTimeFormatDirective.DAY_OF_WEEK_STARTING_WITH_SUNDAY_0.toTokens());
+
+        testFormat("%G", RubyTimeFormatDirective.WEEK_BASED_YEAR_WITH_CENTURY.toTokens());
+        testFormat("%g", RubyTimeFormatDirective.WEEK_BASED_YEAR_WITHOUT_CENTURY.toTokens());
+        testFormat("%V", RubyTimeFormatDirective.WEEK_OF_WEEK_BASED_YEAR.toTokens());
+
+        testFormat("%U", RubyTimeFormatDirective.WEEK_OF_YEAR_STARTING_WITH_SUNDAY.toTokens());
+        testFormat("%W", RubyTimeFormatDirective.WEEK_OF_YEAR_STARTING_WITH_MONDAY.toTokens());
+
+        testFormat("%s", RubyTimeFormatDirective.SECOND_SINCE_EPOCH.toTokens());
+        testFormat("%Q", RubyTimeFormatDirective.MILLISECOND_SINCE_EPOCH.toTokens());
+    }
+
+    @Test
+    public void testRecurred() {
+        testFormat("%c",
+                   RubyTimeFormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens());
+        testFormat("%D",
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('/'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate('/'),
+                   RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+        testFormat("%x",
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('/'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate('/'),
+                   RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+        testFormat("%F",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
+        testFormat("%n",
+                   new RubyTimeFormatToken.Immediate('\n'));
+        testFormat("%R",
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens());
+        testFormat("%r",
+                   RubyTimeFormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens());
+        testFormat("%T",
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens());
+        testFormat("%X",
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens());
+        testFormat("%t",
+                   new RubyTimeFormatToken.Immediate('\t'));
+        testFormat("%v",
+                   RubyTimeFormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens());
+        testFormat("%+",
+                   RubyTimeFormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.TIME_ZONE_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens());
+    }
+
+    @Test
+    public void testExtended() {
+        testFormat("%EC", RubyTimeFormatDirective.CENTURY.toTokens());
+        testFormat("%Oy", RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+        testFormat("%:z", RubyTimeFormatDirective.TIME_OFFSET.toTokens());
+        testFormat("%::z", RubyTimeFormatDirective.TIME_OFFSET.toTokens());
+        testFormat("%:::z", RubyTimeFormatDirective.TIME_OFFSET.toTokens());
+    }
+
+    @Test
+    public void testPercents() {
+        testFormat("%", new RubyTimeFormatToken.Immediate('%'));
+        testFormat("%%", new RubyTimeFormatToken.Immediate('%'));
+
+        // Split into two "%" tokens for some internal reasons.
+        testFormat("%%%", new RubyTimeFormatToken.Immediate('%'), new RubyTimeFormatToken.Immediate('%'));
+        testFormat("%%%%", new RubyTimeFormatToken.Immediate('%'), new RubyTimeFormatToken.Immediate('%'));
+    }
+
+    @Test
+    public void testOrdinary() {
+        testFormat("abc123", new RubyTimeFormatToken.Immediate("abc123"));
+    }
+
+    @Test
+    public void testPercentButOrdinary() {
+        testFormat("%f", new RubyTimeFormatToken.Immediate("%f"));
+        testFormat("%Ed", new RubyTimeFormatToken.Immediate("%Ed"));
+        testFormat("%OY", new RubyTimeFormatToken.Immediate("%OY"));
+        testFormat("%::::z", new RubyTimeFormatToken.Immediate("%::::z"));
+    }
+
+    @Test
+    public void testSpecifiersAndOrdinary() {
+        testFormat("ab%Out%Expose",
+                   new RubyTimeFormatToken.Immediate("ab"),
+                   RubyTimeFormatDirective.DAY_OF_WEEK_STARTING_WITH_MONDAY_1.toTokens(),
+                   new RubyTimeFormatToken.Immediate("t"),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('/'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate('/'),
+                   RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate("pose"));
+    }
+
+    @Test
+    public void testRubyTestPatterns() {
+        testFormat("%Y-%m-%dT%H:%M:%S",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate('T'),
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens());
+        testFormat("%d-%b-%y",
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+        testFormat("%A %B %d %y",
+                   RubyTimeFormatDirective.DAY_OF_WEEK_FULL_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+        testFormat("%B %d, %y",
+                   RubyTimeFormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(", "),
+                   RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+        testFormat("%B%t%d,%n%y",
+                   RubyTimeFormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate('\t'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(','),
+                   new RubyTimeFormatToken.Immediate('\n'),
+                   RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+        testFormat("%I:%M:%S %p",
+                   RubyTimeFormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens());
+        testFormat("%I:%M:%S %p %Z",
+                   RubyTimeFormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens(),
+                   new RubyTimeFormatToken.Immediate(' '),
+                   RubyTimeFormatDirective.TIME_ZONE_NAME.toTokens());
+        testFormat("%a%d%b%y%H%p%Z",
+                   RubyTimeFormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens(),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
+                   RubyTimeFormatDirective.YEAR_WITHOUT_CENTURY.toTokens(),
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   RubyTimeFormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens(),
+                   RubyTimeFormatDirective.TIME_ZONE_NAME.toTokens());
+        testFormat("%Y9%m9%d",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate('9'),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('9'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
+        testFormat("%k%M%S",
+                   RubyTimeFormatDirective.HOUR_OF_DAY_BLANK_PADDED.toTokens(),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens());
+        testFormat("%l%M%S",
+                   RubyTimeFormatDirective.HOUR_OF_AMPM_BLANK_PADDED.toTokens(),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens());
+        testFormat("%Y.",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate('.'));
+        testFormat("%Y. ",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate(". "));
+        testFormat("%Y-%m-%d",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
+        testFormat("%Y-%m-%e",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens());
+        testFormat("%Y-%j",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.DAY_OF_YEAR.toTokens());
+        testFormat("%H:%M:%S",
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens());
+        testFormat("%k:%M:%S",
+                   RubyTimeFormatDirective.HOUR_OF_DAY_BLANK_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens());
+        testFormat("%A,",
+                   RubyTimeFormatDirective.DAY_OF_WEEK_FULL_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(','));
+        testFormat("%B,",
+                   RubyTimeFormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
+                   new RubyTimeFormatToken.Immediate(','));
+        testFormat("%FT%T%Z",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate('T'),
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   RubyTimeFormatDirective.TIME_ZONE_NAME.toTokens());
+        testFormat("%FT%T.%N%Z",
+                   RubyTimeFormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.MONTH_OF_YEAR.toTokens(),
+                   new RubyTimeFormatToken.Immediate('-'),
+                   RubyTimeFormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate('T'),
+                   RubyTimeFormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   new RubyTimeFormatToken.Immediate(':'),
+                   RubyTimeFormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   new RubyTimeFormatToken.Immediate('.'),
+                   RubyTimeFormatDirective.NANO_OF_SECOND.toTokens(),
+                   RubyTimeFormatDirective.TIME_ZONE_NAME.toTokens());
+    }
+
+    private void testFormat(final String formatString, final Object... expectedTokensInArray) {
+        final List<RubyTimeFormatToken> expectedTokens = new ArrayList<>();
+        for (final Object expectedElement : expectedTokensInArray) {
+            if (expectedElement instanceof RubyTimeFormatToken) {
+                expectedTokens.add((RubyTimeFormatToken) expectedElement);
+            } else if (expectedElement instanceof List) {
+                for (final Object expectedElement2 : (List) expectedElement) {
+                    if (expectedElement2 instanceof RubyTimeFormatToken) {
+                        expectedTokens.add((RubyTimeFormatToken) expectedElement2);
+                    } else {
+                        fail();
+                    }
+                }
+            } else {
+                fail();
+            }
+        }
+        final RubyTimeFormat expectedFormat = RubyTimeFormat.createForTesting(expectedTokens);
+        final RubyTimeFormat actualFormat = RubyTimeFormat.compile(formatString);
+        assertEquals(expectedFormat, actualFormat);
+    }
+}

--- a/src/test/java/org/embulk/spi/time/TestTimeZoneIds.java
+++ b/src/test/java/org/embulk/spi/time/TestTimeZoneIds.java
@@ -1,0 +1,18 @@
+package org.embulk.spi.time;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTimeZoneIds {
+    @Test
+    public void testParseZoneIdWithJodaAndRubyZoneTab() {
+        // TODO: Test more practical equality. (Such as "GMT" v.s. "UTC")
+        Assert.assertEquals(ZoneOffset.UTC, TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("Z"));
+        Assert.assertEquals(ZoneId.of("Asia/Tokyo"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("Asia/Tokyo"));
+        Assert.assertEquals(ZoneId.of("-05:00"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("EST"));
+        Assert.assertEquals(ZoneId.of("-10:00"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("HST"));
+        Assert.assertEquals(ZoneId.of("Asia/Taipei"), TimeZoneIds.parseZoneIdWithJodaAndRubyZoneTab("ROC"));
+    }
+}


### PR DESCRIPTION
See 5bd685e75282b377f1e2ba75fb0dab797c288caf of Embulk's source code repository

- https://github.com/embulk/embulk/tree/v0.9.0
- https://github.com/embulk/embulk/commit/5bd685e75282b377f1e2ba75fb0dab797c288caf
- https://github.com/embulk/embulk/tree/v0.9.0/embulk-core/src/main/java/org/embulk/spi/time
- https://github.com/embulk/embulk/tree/v0.9.0/embulk-core/src/test/java/org/embulk/spi/time
