### PR TITLE
Implement java.time.temporal.TemporalAccessor in Parsed

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/RubyChronoField.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyChronoField.java
@@ -1,0 +1,165 @@
+package org.embulk.util.rubytime;
+
+import java.time.Year;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.ValueRange;
+import java.util.Locale;
+
+public final class RubyChronoField {
+    public static final TemporalField WEEK_BASED_YEAR = Field.WEEK_BASED_YEAR;
+
+    public static final TemporalField INSTANT_MILLIS = Field.INSTANT_MILLIS;
+
+    public static final TemporalField WEEK_OF_YEAR_STARTING_WITH_SUNDAY = Field.WEEK_OF_YEAR_STARTING_WITH_SUNDAY;
+
+    public static final TemporalField WEEK_OF_YEAR_STARTING_WITH_MONDAY = Field.WEEK_OF_YEAR_STARTING_WITH_MONDAY;
+
+    public static final TemporalField DAY_OF_WEEK_STARTING_WITH_MONDAY_1 = Field.DAY_OF_WEEK_STARTING_WITH_MONDAY_1;
+
+    public static final TemporalField WEEK_OF_WEEK_BASED_YEAR = Field.WEEK_OF_WEEK_BASED_YEAR;
+
+    public static final TemporalField DAY_OF_WEEK_STARTING_WITH_SUNDAY_0 = Field.DAY_OF_WEEK_STARTING_WITH_SUNDAY_0;
+
+    static enum Field implements TemporalField {
+        WEEK_BASED_YEAR(
+                "WeekBasedYear",
+                ChronoUnit.YEARS,
+                ChronoUnit.FOREVER,
+                ValueRange.of(Year.MIN_VALUE, Year.MAX_VALUE),
+                true,
+                false),
+        INSTANT_MILLIS(
+                "InstantMillis",
+                ChronoUnit.MILLIS,
+                ChronoUnit.FOREVER,
+                ValueRange.of(Long.MIN_VALUE, Long.MAX_VALUE),
+                false,
+                true),
+        WEEK_OF_YEAR_STARTING_WITH_SUNDAY(
+                "WeekOfYearStartingWithSunday",
+                ChronoUnit.WEEKS,
+                ChronoUnit.YEARS,
+                ValueRange.of(0, 53),
+                true,
+                false),
+        WEEK_OF_YEAR_STARTING_WITH_MONDAY(
+                "WeekOfYearStartingWithMonday",
+                ChronoUnit.WEEKS,
+                ChronoUnit.YEARS,
+                ValueRange.of(0, 53),
+                true,
+                false),
+        DAY_OF_WEEK_STARTING_WITH_MONDAY_1(
+                "DayOfWeekStartingWithMonday1",
+                ChronoUnit.DAYS,
+                ChronoUnit.WEEKS,
+                ValueRange.of(1, 7),
+                true,
+                false),
+        WEEK_OF_WEEK_BASED_YEAR(
+                "WeekOfWeekBasedYear",
+                ChronoUnit.WEEKS,
+                ChronoUnit.YEARS,
+                ValueRange.of(1, 53),
+                true,
+                false),
+        DAY_OF_WEEK_STARTING_WITH_SUNDAY_0(
+                "DayOfWeekStartingWithSunday0",
+                ChronoUnit.DAYS,
+                ChronoUnit.WEEKS,
+                ValueRange.of(0, 6),
+                true,
+                false),
+        ;
+
+        private Field(
+                final String name,
+                final TemporalUnit baseUnit,
+                final TemporalUnit rangeUnit,
+                final ValueRange range,
+                final boolean isDateBased,
+                final boolean isTimeBased) {
+            this.name = name;
+            this.baseUnit = baseUnit;
+            this.rangeUnit = rangeUnit;
+            this.range = range;
+            this.isDateBased = isDateBased;
+            this.isTimeBased = isTimeBased;
+        }
+
+        @Override
+        public String getDisplayName(final Locale locale) {
+            return this.name;
+        }
+
+        @Override
+        public TemporalUnit getBaseUnit() {
+            return this.baseUnit;
+        }
+
+        @Override
+        public TemporalUnit getRangeUnit() {
+            return this.rangeUnit;
+        }
+
+        @Override
+        public ValueRange range() {
+            return this.range;
+        }
+
+        @Override
+        public boolean isDateBased() {
+            return this.isDateBased;
+        }
+
+        @Override
+        public boolean isTimeBased() {
+            return this.isTimeBased;
+        }
+
+        public long checkValidValue(final long value) {  // Not from TemporalField.
+            return this.range().checkValidValue(value, this);
+        }
+
+        public int checkValidIntValue(final long value) {  // Not from TemporalField.
+            return this.range().checkValidIntValue(value, this);
+        }
+
+        @Override
+        public boolean isSupportedBy(final TemporalAccessor temporal) {
+            return temporal.isSupported(this);
+        }
+
+        @Override
+        public ValueRange rangeRefinedBy(final TemporalAccessor temporal) {
+            return temporal.range(this);
+        }
+
+        @Override
+        public long getFrom(final TemporalAccessor temporal) {
+            return temporal.getLong(this);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <R extends Temporal> R adjustInto(final R temporal, final long newValue) {
+            return (R) temporal.with(this, newValue);
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+
+        private final String name;
+        private final TemporalUnit baseUnit;
+        private final TemporalUnit rangeUnit;
+        private final ValueRange range;
+        private final boolean isDateBased;
+        private final boolean isTimeBased;
+    }
+}

--- a/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
@@ -1,0 +1,24 @@
+package org.embulk.util.rubytime;
+
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalQuery;
+
+public class RubyTemporalQueries {
+    private RubyTemporalQueries() {
+        // No instantiation.
+    }
+
+    public static TemporalQuery<String> rubyTimeZone() {
+        return RubyTemporalQueries.RUBY_TIME_ZONE;
+    }
+
+    public static TemporalQuery<String> leftover() {
+        return RubyTemporalQueries.LEFTOVER;
+    }
+
+    static final TemporalQuery<String> RUBY_TIME_ZONE =
+            (temporal) -> temporal.query(RubyTemporalQueries.RUBY_TIME_ZONE);
+    static final TemporalQuery<String> LEFTOVER =
+            (temporal) -> temporal.query(RubyTemporalQueries.LEFTOVER);
+}

--- a/src/main/java/org/embulk/util/rubytime/RubyTimeParser.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTimeParser.java
@@ -281,8 +281,7 @@ class RubyTimeParser {
 
                             final long sec = (negative ? -readDigitsMax() : readDigitsMax());
 
-                            builder.setInstantSeconds(
-                                    Instant.ofEpochSecond(sec / 1000L, sec % 1000L * (long) Math.pow(10, 6)));
+                            builder.setInstantMilliseconds(sec);
                             break;
                         }
                         // %S - Second of the minute (00..59)
@@ -303,7 +302,7 @@ class RubyTimeParser {
                             }
 
                             final long sec = readDigitsMax();
-                            builder.setInstantSeconds(Instant.ofEpochSecond(!negative ? sec : -sec, 0));
+                            builder.setInstantMilliseconds((!negative ? sec : -sec) * 1000);
                             break;
                         }
                         // %U, %OU - Week number of the year.  The week starts with Sunday.  (00..53)


### PR DESCRIPTION
It additionally implements interface of `java.time.temporal.TemporalAccessor` into `Parsed` toward being compliant with JSR-310 (Java 8's `java.time`) interface.

Existing methods would be removed in next PRs: #6 and #7.

It's totally NOT in a hurry. Can you have a look when you have some time? @sakama (Cc: @muga)