### PR TITLE
Implement Ruby's Date._strptime on JSR-310 as ParsedElementsQuery

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/Parsed.java
+++ b/src/main/java/org/embulk/util/rubytime/Parsed.java
@@ -144,6 +144,8 @@ final class Parsed implements TemporalAccessor {
             this.chronoFieldValues.put(ChronoField.YEAR, (long) year);  // Not YEAR_OF_ERA.
         }
 
+        // TODO: Parsed should contain "offset" by itself to be consistent with Date._strptime.
+        // This is now done in ParsedElementsQuery to create a Map compatible with Date._strptime.
         this.timeZoneName = timeZoneName;
 
         this.leftover = leftover;
@@ -839,74 +841,6 @@ final class Parsed implements TemporalAccessor {
                     zoneId).plusDays(daysRollover);
         }
         return datetime.toInstant();
-    }
-
-    Map<String, Object> asMapLikeRubyHash() {
-        final HashMap<String, Object> hash = new HashMap<>();
-
-        putIntIfValid(hash, "mday", this.dayOfMonth);
-        putIntIfValid(hash, "cwyear", this.weekBasedYear);
-        putIntIfValid(hash, "hour", this.hour);
-        putIntIfValid(hash, "yday", this.dayOfYear);
-        putFractionIfValid(hash, "sec_fraction", this.nanoOfSecond);
-        putIntIfValid(hash, "min", this.minuteOfHour);
-        putIntIfValid(hash, "mon", this.monthOfYear);
-        putSecondWithFractionIfValid(hash, "seconds", this.instantMilliseconds);
-        putIntIfValid(hash, "sec", (this.parsedLeapSecond ? 60 : this.secondOfMinute));
-        putIntIfValid(hash, "wnum0", this.weekOfYearStartingWithSunday);
-        putIntIfValid(hash, "wnum1", this.weekOfYearStartingWithMonday);
-        putIntIfValid(hash, "cwday", this.dayOfWeekStartingWithMonday1);
-        putIntIfValid(hash, "cweek", this.weekOfWeekBasedYear);
-        putIntIfValid(hash, "wday", this.dayOfWeekStartingWithSunday0);
-        putIntIfValid(hash, "year", this.year);
-        putTimeZoneIfValid(hash, this.timeZoneName);
-        putStringIfValid(hash, "leftover", this.leftover);
-
-        return hash;
-    }
-
-    private int putIntIfValid(final Map<String, Object> hash, final String key, final int value) {
-        if (value != Integer.MIN_VALUE) {
-            hash.put(key, value);
-        }
-        return value;
-    }
-
-    private BigDecimal putFractionIfValid(final Map<String, Object> hash, final String key, final int value) {
-        if (value != Integer.MIN_VALUE) {
-            return (BigDecimal) hash.put(key, BigDecimal.ZERO.add(BigDecimal.valueOf(value, 9)));
-        }
-        return null;
-    }
-
-    private Object putSecondWithFractionIfValid(final Map<String, Object> hash, final String key, final long value) {
-        if (value != Long.MIN_VALUE) {
-            if (value % 1000 == 0) {
-                return hash.put(key, value / 1000);
-            } else {
-                return hash.put(key,
-                                BigDecimal.valueOf(value / 1000).add(BigDecimal.valueOf(value % 1000, 3)));
-            }
-        }
-        return null;
-    }
-
-    private String putTimeZoneIfValid(final Map<String, Object> hash, final String timeZoneName) {
-        if (timeZoneName != null) {
-            final int offset = RubyTimeZoneTab.dateZoneToDiff(timeZoneName);
-            if (offset != Integer.MIN_VALUE) {
-                hash.put("offset", offset);
-            }
-            return (String) hash.put("zone", timeZoneName);
-        }
-        return timeZoneName;
-    }
-
-    private String putStringIfValid(final Map<String, Object> hash, final String key, final String value) {
-        if (value != null) {
-            return (String) hash.put(key, value);
-        }
-        return value;
     }
 
     /**

--- a/src/main/java/org/embulk/util/rubytime/ParsedElementsQuery.java
+++ b/src/main/java/org/embulk/util/rubytime/ParsedElementsQuery.java
@@ -1,0 +1,190 @@
+package org.embulk.util.rubytime;
+
+import java.math.BigDecimal;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalQuery;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Queries to provide Maps of parsed elements, which are analogous to Ruby hashes by Date._strptime.
+ */
+public class ParsedElementsQuery<T> implements TemporalQuery<Map<T, Object>> {
+    public static interface FractionConverter {
+        Object convertFraction(int seconds, int nanoOfSecond);
+    }
+
+    public static interface HashKeyConverter<T> {
+        T convertHashKey(String hashKey);
+    }
+
+    private ParsedElementsQuery(
+            final FractionConverter fractionConverter,
+            final HashKeyConverter<T> hashKeyConverter) {
+        this.fractionConverter = fractionConverter;
+        this.hashKeyConverter = hashKeyConverter;
+    }
+
+    public static ParsedElementsQuery<String> withFractionInBigDecimal() {
+        return new ParsedElementsQuery<String>(FRACTION_TO_BIG_DECIMAL, STRING_AS_IS);
+    }
+
+    public static ParsedElementsQuery<String> of(final FractionConverter fractionConverter) {
+        return new ParsedElementsQuery<String>(fractionConverter, STRING_AS_IS);
+    }
+
+    public static <U> ParsedElementsQuery<U> of(
+            final FractionConverter fractionConverter,
+            final HashKeyConverter<U> hashKeyConverter) {
+        return new ParsedElementsQuery<U>(fractionConverter, hashKeyConverter);
+    }
+
+    @Override
+    public Map<T, Object> queryFrom(final TemporalAccessor temporal) {
+        final Builder<T> builder = new Builder<T>(temporal, this.fractionConverter, this.hashKeyConverter);
+
+        builder.put("mday", ChronoField.DAY_OF_MONTH);
+        builder.put("cwyear", RubyChronoField.WEEK_BASED_YEAR);
+        builder.putHourOfDay();
+        builder.put("yday", ChronoField.DAY_OF_YEAR);
+        builder.putSecFraction();
+        builder.put("min", ChronoField.MINUTE_OF_HOUR);
+        builder.put("mon", ChronoField.MONTH_OF_YEAR);
+        builder.putInstantMillisecond();
+        builder.putSecondOfMinute();
+        builder.put("wnum0", RubyChronoField.WEEK_OF_YEAR_STARTING_WITH_SUNDAY);
+        builder.put("wnum1", RubyChronoField.WEEK_OF_YEAR_STARTING_WITH_MONDAY);
+        builder.put("cwday", RubyChronoField.DAY_OF_WEEK_STARTING_WITH_MONDAY_1);
+        builder.put("cweek", RubyChronoField.WEEK_OF_WEEK_BASED_YEAR);
+        builder.put("wday", RubyChronoField.DAY_OF_WEEK_STARTING_WITH_SUNDAY_0);
+        builder.put("year", ChronoField.YEAR);
+
+        builder.putTimeZone();
+        builder.putLeftover();
+
+        return builder.build();
+    }
+
+    private static class Builder<T> {
+        private Builder(
+                final TemporalAccessor temporal,
+                final FractionConverter fractionConverterInner,
+                final HashKeyConverter<T> hashKeyConverter) {
+            this.temporal = temporal;
+            this.fractionConverterInner = fractionConverterInner;
+            this.hashKeyConverter = hashKeyConverter;
+            this.built = new HashMap<>();
+        }
+
+        private void put(final String key, final TemporalField field) {
+            if (this.temporal.isSupported(field)) {
+                this.built.put(this.hashKeyConverter.convertHashKey(key), this.temporal.get(field));
+            }
+        }
+
+        private void putHourOfDay() {
+            if (this.temporal.isSupported(ChronoField.HOUR_OF_DAY)) {
+                final Period parsedExcessDays = this.temporal.query(DateTimeFormatter.parsedExcessDays());
+                if (parsedExcessDays == null || parsedExcessDays.isZero()) {
+                    this.built.put(this.hashKeyConverter.convertHashKey("hour"),
+                                   this.temporal.get(ChronoField.HOUR_OF_DAY));
+                } else if (parsedExcessDays.getDays() == 1
+                                   && parsedExcessDays.getMonths() == 0
+                                   && parsedExcessDays.getYears() == 0) {
+                    this.built.put(this.hashKeyConverter.convertHashKey("hour"), 24);
+                }
+            }
+        }
+
+        private void putSecondOfMinute() {
+            if (this.temporal.isSupported(ChronoField.SECOND_OF_MINUTE)) {
+                if (this.temporal.query(DateTimeFormatter.parsedLeapSecond())) {
+                    this.built.put(this.hashKeyConverter.convertHashKey("sec"), 60);
+                } else {
+                    this.built.put(this.hashKeyConverter.convertHashKey("sec"),
+                                   this.temporal.get(ChronoField.SECOND_OF_MINUTE));
+                }
+            }
+        }
+
+        private void putSecFraction() {
+            if (this.temporal.isSupported(ChronoField.NANO_OF_SECOND)) {
+                this.built.put(this.hashKeyConverter.convertHashKey("sec_fraction"),
+                               this.fractionConverterInner.convertFraction(
+                                       0, this.temporal.get(ChronoField.NANO_OF_SECOND)));
+            }
+        }
+
+        private void putInstantMillisecond() {
+            if (this.temporal.isSupported(RubyChronoField.INSTANT_MILLIS)) {
+                final long instantMillisecond = this.temporal.getLong(RubyChronoField.INSTANT_MILLIS);
+                final int instantSecond = (int) (instantMillisecond / 1000);
+                final int nanoOfInstantSecond = (int) (instantMillisecond % 1000) * 1_000_000;
+                if (nanoOfInstantSecond == 0) {
+                    this.built.put(this.hashKeyConverter.convertHashKey("seconds"), instantSecond);
+                } else {
+                    this.built.put(this.hashKeyConverter.convertHashKey("seconds"),
+                                   this.fractionConverterInner.convertFraction(
+                                           instantSecond, nanoOfInstantSecond));
+                }
+            }
+        }
+
+        private void putTimeZone() {
+            final String zone = temporal.query(RubyTemporalQueries.rubyTimeZone());
+            if (zone != null) {
+                final int offset = RubyTimeZoneTab.dateZoneToDiff(zone);
+                if (offset != Integer.MIN_VALUE) {
+                    this.built.put(this.hashKeyConverter.convertHashKey("offset"), offset);
+                }
+                this.built.put(this.hashKeyConverter.convertHashKey("zone"), zone);
+            }
+        }
+
+        private void putLeftover() {
+            final String leftover = temporal.query(RubyTemporalQueries.leftover());
+            if (leftover != null) {
+                this.built.put(this.hashKeyConverter.convertHashKey("leftover"), leftover);
+            }
+        }
+
+        private Map<T, Object> build() {
+            return Collections.unmodifiableMap(this.built);
+        }
+
+        private final TemporalAccessor temporal;
+        private final FractionConverter fractionConverterInner;
+        private final HashKeyConverter<T> hashKeyConverter;
+        private final HashMap<T, Object> built;
+    }
+
+    private static final FractionToBigDecimalConverter FRACTION_TO_BIG_DECIMAL;
+    private static final HashKeyConverter<String> STRING_AS_IS;
+
+    private final static class FractionToBigDecimalConverter implements FractionConverter {
+        @Override
+        public Object convertFraction(final int seconds, final int nanoOfSecond) {
+            return BigDecimal.valueOf(seconds).add(BigDecimal.valueOf(nanoOfSecond, 9));
+        }
+    }
+
+    private final static class StringAsIs implements HashKeyConverter<String> {
+        @Override
+        public String convertHashKey(final String hashKey) {
+            return hashKey;
+        }
+    }
+
+    static {
+        FRACTION_TO_BIG_DECIMAL = new FractionToBigDecimalConverter();
+        STRING_AS_IS = new StringAsIs();
+    }
+
+    private final FractionConverter fractionConverter;
+    private final HashKeyConverter<T> hashKeyConverter;
+}

--- a/src/main/java/org/embulk/util/rubytime/RubyTimeParser.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTimeParser.java
@@ -1,6 +1,7 @@
 package org.embulk.util.rubytime;
 
 import java.time.Instant;
+import java.time.temporal.TemporalAccessor;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -38,7 +39,7 @@ class RubyTimeParser {
         this.format = format;
     }
 
-    public Parsed parse(final String text) {
+    public TemporalAccessor parse(final String text) {
         return new StringParser(text).parse(this.format);
     }
 

--- a/src/test/java/org/embulk/util/rubytime/FractionToJRubyRationalConverter.java
+++ b/src/test/java/org/embulk/util/rubytime/FractionToJRubyRationalConverter.java
@@ -1,0 +1,18 @@
+package org.embulk.util.rubytime;
+
+import org.jruby.Ruby;
+import org.jruby.RubyRational;
+
+public class FractionToJRubyRationalConverter implements ParsedElementsQuery.FractionConverter {
+    public FractionToJRubyRationalConverter(final Ruby ruby) {
+        this.ruby = ruby;
+    }
+
+    @Override
+    public Object convertFraction(final int seconds, final int nanoOfSecond) {
+        return RubyRational.newRational(
+                this.ruby, ((long) seconds * 1_000_000_000L) + (long) nanoOfSecond, 1_000_000_000L);
+    }
+
+    private final Ruby ruby;
+}

--- a/src/test/java/org/embulk/util/rubytime/HashKeyToJRubySymbolConverter.java
+++ b/src/test/java/org/embulk/util/rubytime/HashKeyToJRubySymbolConverter.java
@@ -1,0 +1,17 @@
+package org.embulk.util.rubytime;
+
+import org.jruby.Ruby;
+import org.jruby.RubySymbol;
+
+public class HashKeyToJRubySymbolConverter implements ParsedElementsQuery.HashKeyConverter<RubySymbol> {
+    public HashKeyToJRubySymbolConverter(final Ruby ruby) {
+        this.ruby = ruby;
+    }
+
+    @Override
+    public RubySymbol convertHashKey(final String hashKey) {
+        return RubySymbol.newSymbol(this.ruby, hashKey);
+    }
+
+    private final Ruby ruby;
+}

--- a/src/test/java/org/embulk/util/rubytime/TestParsedElementsQuery.java
+++ b/src/test/java/org/embulk/util/rubytime/TestParsedElementsQuery.java
@@ -1,0 +1,31 @@
+package org.embulk.util.rubytime;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Tests RubyParsedElementsQuery.
+ */
+public class TestParsedElementsQuery {
+    @Test
+    public void test() {
+        final Parsed.Builder builder = Parsed.builder("foo");
+        builder.setInstantMilliseconds(123456789);
+        builder.setHour(11);
+        builder.setDayOfYear(92);
+        builder.setWeekBasedYear(1998);
+        builder.setLeftover("foobar");
+        final Parsed parsed = builder.build();
+        final Map<String, Object> parsedElements = parsed.query(ParsedElementsQuery.withFractionInBigDecimal());
+
+        assertEquals(BigDecimal.valueOf(123456).add(BigDecimal.valueOf(789000000, 9)),
+                     parsedElements.get("seconds"));
+        assertEquals(11, parsedElements.get("hour"));
+        assertEquals(92, parsedElements.get("yday"));
+        assertEquals(1998, parsedElements.get("cwyear"));
+        assertEquals("foobar", parsedElements.get("leftover"));
+    }
+}

--- a/src/test/resources/date_monkey_patch.rb
+++ b/src/test/resources/date_monkey_patch.rb
@@ -6,33 +6,20 @@ module DateMonkeyPatch
   def self.included base
     base.instance_eval do
       def _strptime(str, fmt='%F')
-        map = parse_with_embulk_ruby_time_parser(fmt, str)
-        return map.nil? ? nil : map.to_hash.inject({}){|hash,(k,v)| hash[k.to_sym] = v; hash}
-      end
+        parser = Java::org.embulk.util.rubytime.RubyTimeParser.new(
+          Java::org.embulk.util.rubytime.RubyTimeFormat.compile(fmt))
 
-      def parse_with_embulk_ruby_time_parser(fmt, str)
-        format = Java::org.embulk.util.rubytime.RubyTimeFormat.compile(fmt)
-        parser = Java::org.embulk.util.rubytime.RubyTimeParser.new(format)
-        time_parse_result = parser.parse(str)
-        if time_parse_result.nil?
+        parsed = parser.parse(str)
+        if parsed.nil?
           return nil
         end
-        return convert_time_parse_result_to_ruby_hash(time_parse_result)
-      end
 
-      def convert_time_parse_result_to_ruby_hash(time_parse_result)
-        ruby_hash = {}
-        time_parse_result.asMapLikeRubyHash().each do |key, value|
-          if value.kind_of?(Java::java.math.BigDecimal)
-            nanosecond = value.multiply(Java::java.math.BigDecimal::TEN.pow(9)).longValue();
-            ruby_hash[key.to_s] = Rational(nanosecond, 10 ** 9)
-          else
-            ruby_hash[key.to_s] = value
-          end
-        end
-        return ruby_hash
-      end
+        map = parsed.query(Java::org.embulk.util.rubytime.ParsedElementsQuery.of(
+                             Java::org.embulk.util.rubytime.FractionToJRubyRationalConverter.new(JRuby.runtime),
+                             Java::org.embulk.util.rubytime.HashKeyToJRubySymbolConverter.new(JRuby.runtime)))
 
+        return map.nil? ? nil : map.to_hash
+      end
     end
   end
 end


### PR DESCRIPTION
It implements a way compatible with Ruby's [`Date._strptime`](https://ruby-doc.org/stdlib-2.5.0/libdoc/date/rdoc/DateTime.html#method-c-_strptime) in a manner of JSR-310.

It is tested/confirmed with Ruby's `test/date/test_date_strptime.rb` with monkey-patching Ruby's `Date` class with [`date_monkey_patch.rb`](https://github.com/embulk/embulk-util-rubytime/pull/6/files#diff-838adc4dea376c922f17bda061cadf07).

It comes after #4, and it's totally NOT in a hurry. Can you have a look when you have some time? @sakama (Cc: @muga)