### PR TITLE
Implement RubyTimeResolver, and DefaultRubyTimeResolver to emulate resolution by Ruby's Time.strptime

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/DefaultRubyTimeResolver.java
+++ b/src/main/java/org/embulk/util/rubytime/DefaultRubyTimeResolver.java
@@ -1,0 +1,382 @@
+package org.embulk.util.rubytime;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalQuery;
+import java.time.temporal.ValueRange;
+
+/**
+ * Resolves date/time from TemporalAccessor parsed by RubyTimeParser by the same rule as Ruby's Time.strptime.
+ *
+ * <p>A difference from Ruby's {@code Time.strptime} is that it does not consider "now" and local time zone.
+ * If the given zone is neither numerical nor predefined textual time zones, it returns defaultZoneOffset then.
+ *
+ * <p>Ruby's {@code Time} class implements a proleptic Gregorian calendar and has no concept of calendar reform.
+ *
+ * @see <a href="https://docs.ruby-lang.org/en/2.5.0/DateTime.html#class-DateTime-label-When+should+you+use+DateTime+and+when+should+you+use+Time-3F">When should you use DateTime and when should you use Time?</a>
+ *
+ * <p>A fraction from epoch milliseconds (%Q) is prioritized over fraction part of seconds (%N).
+ *
+ * <pre>{@code
+ * irb(main):001:0> require 'time'
+ * => true
+ * irb(main):002:0> Time.strptime("123456789 12.345", "%Q %S.%N").nsec
+ * => 789000000
+ * irb(main):003:0> Time.strptime("12.345 123456789", "%S.%N %Q").nsec
+ * => 789000000
+ * irb(main):004:0> Time.strptime("12.345", "%S.%N").nsec
+ * => 345000000
+ * }
+ * </pre>
+ *
+ * <p>Day of the year (yday: {@code DAY_OF_YEAR}) is not considered unlike {@code DateTime.strptime}.
+ *
+ * <pre>{@code
+ * irb(main):002:0> Time.strptime("2001-128T23:59:59", "%Y-%jT%H:%M:%S")
+ * => 2001-01-01 23:59:59 +0900
+ * irb(main):004:0> DateTime.strptime("2001-128T23:59:59", "%Y-%jT%H:%M:%S")
+ * => #<DateTime: 2001-05-08T23:59:59+00:00 ((2452038j,86399s,0n),+0s,2299161j)>
+ * }
+ * </pre>
+ *
+ * <p>The resolver is reimplemented based on {@code Time.strptime} of Ruby v2.5.0.
+ *
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_5_0/lib/time.rb?view=markup#l431">Time.strptime</a>
+ */
+public class DefaultRubyTimeResolver implements RubyTimeResolver {
+    private DefaultRubyTimeResolver(
+            final boolean acceptsEmpty,
+            final ZoneOffset defaultOffset,
+            final int defaultYear,
+            final int defaultMonthOfYear,
+            final int defaultDayOfMonth,
+            final int defaultHourOfDay,
+            final int defaultMinuteOfHour,
+            final int defaultSecondOfMinute,
+            final int defaultNanoOfSecond) {
+        this.acceptsEmpty = acceptsEmpty;
+        this.defaultOffset = defaultOffset;
+        this.defaultYear = defaultYear;
+        this.defaultMonthOfYear = defaultMonthOfYear;
+        this.defaultDayOfMonth = defaultDayOfMonth;
+        this.defaultHourOfDay = defaultHourOfDay;
+        this.defaultMinuteOfHour = defaultMinuteOfHour;
+        this.defaultSecondOfMinute = defaultSecondOfMinute;
+        this.defaultNanoOfSecond = defaultNanoOfSecond;
+    }
+
+    public static DefaultRubyTimeResolver of() {
+        return new DefaultRubyTimeResolver(false, ZoneOffset.UTC, 1970, 1, 1, 0, 0, 0, 0);
+    }
+
+    public static DefaultRubyTimeResolver withEmptyAccepted() {
+        return new DefaultRubyTimeResolver(true, ZoneOffset.UTC, 1970, 1, 1, 0, 0, 0, 0);
+    }
+
+    private class Resolved implements TemporalAccessor {
+        private Resolved(
+                final TemporalAccessor original,
+                final OffsetDateTime resolvedDateTime) {
+            this.original = original;
+            this.resolvedDateTime = resolvedDateTime;
+        }
+
+        @Override
+        public long getLong(final TemporalField field) {
+            if (this.original.isSupported(field)) {
+                return this.original.getLong(field);
+            }
+            return this.resolvedDateTime.getLong(field);
+        }
+
+        @Override
+        public boolean isSupported(final TemporalField field) {
+            if (this.original.isSupported(field)) {
+                return true;
+            }
+            return this.resolvedDateTime.isSupported(field);
+        }
+
+        @Override
+        public <R> R query(final TemporalQuery<R> query) {
+            final R resultOriginal = this.original.query(query);
+            if (resultOriginal != null) {
+                return resultOriginal;
+            }
+            return this.resolvedDateTime.query(query);
+        }
+
+        @Override
+        public ValueRange range(final TemporalField field) {
+            if (this.original.isSupported(field)) {
+                return this.original.range(field);
+            }
+            return this.resolvedDateTime.range(field);
+        }
+
+        private final TemporalAccessor original;
+        private final OffsetDateTime resolvedDateTime;
+    }
+
+    @Override
+    public TemporalAccessor resolve(final TemporalAccessor original) throws RubyTimeResolveException {
+        final String zone = original.query(RubyTemporalQueries.rubyTimeZone());
+        final ZoneOffset offset = TimeZoneIds.parseRubyTimeZoneOffset(zone, defaultOffset);
+
+        if (offset == null) {
+            if (zone == null) {
+                throw new RubyTimeResolveException("Empty time zone ID.");
+            } else {
+                throw new RubyTimeResolveException("Invalid time zone ID: '" + zone);
+            }
+        }
+
+        if (original.isSupported(RubyChronoField.INSTANT_MILLIS)
+                    || original.isSupported(ChronoField.INSTANT_SECONDS)) {
+            final long instantMilliseconds;
+            if (original.isSupported(RubyChronoField.INSTANT_MILLIS)) {
+                instantMilliseconds = original.getLong(RubyChronoField.INSTANT_MILLIS);
+            } else {  // ChronoField.INSTANT_SECONDS should be supported at this point.
+                instantMilliseconds = original.getLong(ChronoField.INSTANT_SECONDS) * 1000;
+            }
+
+            // TODO: Store the zone offset information in Resolved, instead of ZoneOffset.UTC.
+            //
+            // INSTANT_SECONDS by itself is always a value as of UTC, but results of
+            // Ruby's Time.strptime can have non-UTC offsets.
+            //
+            // From test/test_time.rb,
+            //    t = Time.strptime('0 +0100', '%s %z')
+            //    assert_equal(0, t.to_r)
+            //    assert_equal(3600, t.utc_offset)
+            //
+            // The test is working-around it by getting zone offset from Parsed, not Resolved.
+            return new Resolved(
+                    original,
+                    OffsetDateTime.ofInstant(Instant.ofEpochMilli(instantMilliseconds), ZoneOffset.UTC));
+        }
+
+        return new Resolved(original, this.getOffsetAppliedDateTime(original, offset));
+    }
+
+    /**
+     * Applies time zone offset to date/time information, and creates java.time.OffsetDateTime in UTC.
+     *
+     * The method is reimplemented based on apply_offset from Ruby v2.3.1's lib/time.rb.
+     *
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l208">apply_offset</a>
+     */
+    private OffsetDateTime getOffsetAppliedDateTime(
+            final TemporalAccessor original, final ZoneOffset zoneOffset) throws RubyTimeResolveException {
+        final Boolean parsedLeapSecond = original.query(DateTimeFormatter.parsedLeapSecond());
+        final Period parsedExcessDays = original.query(DateTimeFormatter.parsedExcessDays());
+
+        if (!this.acceptsEmpty
+                    && !original.isSupported(ChronoField.YEAR)
+                    && !original.isSupported(ChronoField.MONTH_OF_YEAR)
+                    && !original.isSupported(ChronoField.DAY_OF_MONTH)
+                    && !original.isSupported(ChronoField.HOUR_OF_DAY)
+                    && !original.isSupported(ChronoField.MINUTE_OF_HOUR)
+                    && !original.isSupported(ChronoField.SECOND_OF_MINUTE)
+                    && !original.isSupported(ChronoField.NANO_OF_SECOND)) {
+            throw new RubyTimeResolveException("No time information.");
+        }
+
+        int year = original.isSupported(ChronoField.YEAR)
+                ? original.get(ChronoField.YEAR) : this.defaultYear;
+        int monthOfYear = original.isSupported(ChronoField.MONTH_OF_YEAR)
+                ? original.get(ChronoField.MONTH_OF_YEAR) : this.defaultMonthOfYear;
+        int dayOfMonth = original.isSupported(ChronoField.DAY_OF_MONTH)
+                ? original.get(ChronoField.DAY_OF_MONTH) : this.defaultDayOfMonth;
+        int hourOfDay = original.isSupported(ChronoField.HOUR_OF_DAY)
+                ? original.get(ChronoField.HOUR_OF_DAY) : this.defaultHourOfDay;
+        int minuteOfHour = original.isSupported(ChronoField.MINUTE_OF_HOUR)
+                ? original.get(ChronoField.MINUTE_OF_HOUR) : this.defaultMinuteOfHour;
+        int secondOfMinute = original.isSupported(ChronoField.SECOND_OF_MINUTE)
+                ? original.get(ChronoField.SECOND_OF_MINUTE) : this.defaultSecondOfMinute;
+        int nanoOfSecond = original.isSupported(ChronoField.NANO_OF_SECOND)
+                ? original.get(ChronoField.NANO_OF_SECOND) : this.defaultNanoOfSecond;
+
+        int offset = zoneOffset.getTotalSeconds();
+
+        // Processing leap seconds using time offsets in a bit tricky manner.
+        //
+        // Leap seconds are considered as the next second in Time.strptime.
+        //
+        // irb(main):002:0> Time.strptime("2001-02-03T23:59:60", "%Y-%m-%dT%H:%M:%S")
+        // => 2001-02-04 00:00:00 +0900
+        if (parsedLeapSecond != null && (boolean) parsedLeapSecond) {
+            secondOfMinute = 59;
+            offset -= 1;
+        }
+
+        // Processing 24h in clock hours using time offsets in a bit tricky manner.
+        //
+        // 24h is considered as 0h in the next day in Time.strptime (if non-UTC time zone is specified).
+        //
+        // irb(main):002:0> Time.strptime("24:59:59 PST", "%H:%M:%S %Z")
+        // => 2018-01-13 00:59:59 -0800
+        // irb(main):003:0> Time.strptime("24:59:59 UTC", "%H:%M:%S %Z")
+        // ArgumentError: min out of range
+        // ...
+        // irb(main):004:0> Time.strptime("24:59:59", "%H:%M:%S")
+        // ArgumentError: min out of range
+        // ...
+        //
+        // 24h is always handled as 0h in the next day in Embulk as if non-UTC time zone is specified.
+        if (parsedExcessDays != null) {
+            if (parsedExcessDays.getDays() == 1
+                        && parsedExcessDays.getMonths() == 0
+                        && parsedExcessDays.getYears() == 0) {
+                offset -= 24 * 60 * 60;
+                hourOfDay = 0;
+            } else if (!parsedExcessDays.isZero()) {
+                throw new RubyTimeResolveException("Hour is not in the range of 0-24.");
+            }
+        }
+
+        if (offset < 0) {
+            offset = -offset;
+
+            final int offsetSecond = offset % 60;
+            offset = offset / 60;
+            if (offsetSecond != 0) {
+                secondOfMinute += offsetSecond;
+                offset += secondOfMinute / 60;
+                secondOfMinute %= 60;
+            }
+
+            final int offsetMinute = offset % 60;
+            offset = offset / 60;
+            if (offsetMinute != 0) {
+                minuteOfHour += offsetMinute;
+                offset += minuteOfHour / 60;
+                minuteOfHour %= 60;
+            }
+
+            final int offsetHour = offset % 24;
+            offset = offset / 24;
+            if (offsetHour != 0) {
+                hourOfDay += offsetHour;
+                offset += hourOfDay / 24;
+                hourOfDay %= 24;
+            }
+
+            if (offset != 0) {
+                dayOfMonth += offset;
+                final int days = monthDays(year, monthOfYear);
+                if (days < dayOfMonth) {
+                    monthOfYear += 1;
+                    if (12 < monthOfYear) {
+                        monthOfYear = 1;
+                        year += 1;
+                    }
+                    dayOfMonth = 1;
+                }
+            }
+
+        } else if (0 < offset) {
+            final int offsetSecond = offset % 60;
+            offset /= 60;
+            if (offsetSecond != 0) {
+                secondOfMinute -= offsetSecond;
+                offset -= secondOfMinute / 60;
+                secondOfMinute %= 60;
+            }
+
+            final int offsetMinute = offset % 60;
+            offset /= 60;
+            if (offsetMinute != 0) {
+                minuteOfHour -= offsetMinute;
+                offset -= minuteOfHour / 60;
+                minuteOfHour %= 60;
+            }
+
+            final int offsetHour = offset % 24;
+            offset /= 24;
+            if (offsetHour != 0) {
+                hourOfDay -= offsetHour;
+                offset -= hourOfDay / 24;
+                hourOfDay %= 24;
+            }
+
+            if (offset != 0) {
+                dayOfMonth -= offset;
+                if (dayOfMonth < 1) {
+                    monthOfYear -= 1;
+                    if (monthOfYear < 1) {
+                        year -= 1;
+                        monthOfYear = 12;
+                    }
+                    dayOfMonth = monthDays(year, monthOfYear);
+                }
+            }
+        }
+
+        try {
+            return OffsetDateTime.of(
+                    year, monthOfYear, dayOfMonth, hourOfDay, minuteOfHour, secondOfMinute, nanoOfSecond,
+                    ZoneOffset.UTC);
+        } catch (DateTimeException ex) {
+            throw new RubyTimeResolveException(ex);
+        }
+    }
+
+    private int getWithDefaultOrThrow(
+            final TemporalAccessor original,
+            final TemporalField field,
+            final int defaultValue) throws RubyTimeResolveException {
+        if (original.isSupported(field)) {
+            return original.get(field);
+        } else {
+            if (this.acceptsEmpty) {
+                return defaultValue;
+            } else {
+                throw new RubyTimeResolveException("No time information enough.");
+            }
+        }
+    }
+
+    /**
+     * Returns the number of days in the given month of the given year.
+     *
+     * The method is reimplemented based on month_days from Ruby v2.3.1's lib/time.rb.
+     *
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l199">month_days</a>
+     */
+    private static int monthDays(final int year, final int monthOfYear) {
+        if (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)) {
+            return leapYearMonthDays[monthOfYear - 1];
+        } else {
+            return commonYearMonthDays[monthOfYear - 1];
+        }
+    }
+
+    /**
+     * Numbers of days per month and year.
+     *
+     * The constants are imported from LeapYearMonthDays and CommonYearMonthDays in Ruby v2.3.1's lib/time.rb.
+     *
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l197">LeapYearMonthDays</a>
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l198">CommonYearMonthDays</a>
+     */
+    private static final int[] leapYearMonthDays = { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+    private static final int[] commonYearMonthDays = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+
+    private final boolean acceptsEmpty;
+    private final ZoneOffset defaultOffset;
+    private final int defaultYear;
+    private final int defaultMonthOfYear;
+    private final int defaultDayOfMonth;
+    private final int defaultHourOfDay;
+    private final int defaultMinuteOfHour;
+    private final int defaultSecondOfMinute;
+    private final int defaultNanoOfSecond;
+}

--- a/src/main/java/org/embulk/util/rubytime/RubyTimeResolveException.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTimeResolveException.java
@@ -1,0 +1,15 @@
+package org.embulk.util.rubytime;
+
+public class RubyTimeResolveException extends Exception {
+    public RubyTimeResolveException(final String message) {
+        super(message);
+    }
+
+    public RubyTimeResolveException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public RubyTimeResolveException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/embulk/util/rubytime/RubyTimeResolver.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTimeResolver.java
@@ -1,0 +1,10 @@
+package org.embulk.util.rubytime;
+
+import java.time.temporal.TemporalAccessor;
+
+/**
+ * Resolves date/time from TemporalAccessor parsed by RubyTimeParser.
+ */
+public interface RubyTimeResolver {
+    TemporalAccessor resolve(TemporalAccessor source) throws RubyTimeResolveException;
+}

--- a/src/test/java/org/embulk/util/rubytime/TestRubyTimeParserWithJRuby.java
+++ b/src/test/java/org/embulk/util/rubytime/TestRubyTimeParserWithJRuby.java
@@ -131,10 +131,14 @@ public class TestRubyTimeParserWithJRuby {
         config.processArguments(arguments);
 
         jruby.runScriptlet("require 'date'");
+        jruby.runScriptlet("require 'time'");
         jruby.runScriptlet("require 'test/unit'");
         jruby.runScriptlet(
                 TestRubyTimeParserWithJRuby.class.getClassLoader().getResourceAsStream("date_monkey_patch.rb"),
                 "date_monkey_patch.rb");
+        jruby.runScriptlet(
+                TestRubyTimeParserWithJRuby.class.getClassLoader().getResourceAsStream("time_monkey_patch.rb"),
+                "time_monkey_patch.rb");
 
         // Require test files from Java resource.
         jruby.runScriptlet("require 'ruby/test/date/test_date_strptime.rb'");

--- a/src/test/resources/time_monkey_patch.rb
+++ b/src/test/resources/time_monkey_patch.rb
@@ -1,0 +1,69 @@
+module TimeMonkeyPatch
+  require 'java'
+
+  java_package 'org.embulk.util.rubytime'
+
+  def self.included base
+    base.instance_eval do
+      def strptime(date, format)
+        parser = Java::org.embulk.util.rubytime.RubyTimeParser.new(
+          Java::org.embulk.util.rubytime.RubyTimeFormat.compile(format))
+
+        parsed = parser.parse(date)
+        if parsed.nil?
+          return nil
+        end
+
+        resolver = Java::org.embulk.util.rubytime.DefaultRubyTimeResolver.of()
+
+        begin
+          resolved = resolver.resolve(parsed)
+        rescue Java::org.embulk.util.rubytime.RubyTimeResolveException
+          raise ArgumentError, "no time information in #{date.inspect}"
+        end
+
+        instant_seconds = resolved.getLong(Java::java.time.temporal.ChronoField::INSTANT_SECONDS)
+        nano = resolved.get(Java::java.time.temporal.ChronoField::NANO_OF_SECOND)
+
+        # TODO: Get the zone offset directly from the resolved object, not from the parsed object.
+        zone_string = parsed.query(Java::org.embulk.util.rubytime.RubyTemporalQueries.rubyTimeZone())
+        offset = Java::org.embulk.util.rubytime.TimeZoneIds.parseRubyTimeZoneOffset(
+          zone_string, Java::java.time.ZoneOffset::UTC).getTotalSeconds()
+
+        # Workaround against difference in handling "UTC" between Matz' Ruby Implementation (MRI) and JRuby.
+        #
+        # In MRI 2.5.0:
+        #   irb(main):002:0> mri_time = Time.new(2018, 1, 2, 3, 4, 5, 0)
+        #   => 2018-01-02 03:04:05 +0000
+        #   irb(main):003:0> mri_time.utc?
+        #   => false
+        #
+        # In JRuby (as of 9.1.15.0):
+        #   irb(main):002:0> jruby_time = Time.new(2018, 1, 2, 3, 4, 5, 0)
+        #   => 2018-01-02 03:04:05 UTC
+        #   irb(main):003:0> jruby_time.utc?
+        #   => true
+        #
+        # Due to this difference, without this workaround, TestTimeExtension::test_strptime fails at:
+        #     assert_equal(false, Time.strptime('0', '%s').utc?)
+        if offset == 0 && zone_string != "UTC"
+          ruby_time = Java::org.jruby.RubyTime.newTime(
+            JRuby.runtime,
+            Java::org.joda.time.DateTime.new((instant_seconds * 1000) + (nano / 1000000),
+                                             Java::org.joda.time.DateTimeZone::forID("Etc/UTC")),
+            nano % 1000000)
+        else
+          ruby_time = Java::org.jruby.RubyTime.newTime(
+            JRuby.runtime,
+            Java::org.joda.time.DateTime.new((instant_seconds * 1000) + (nano / 1000000)),
+            nano % 1000000
+          ).localtime(offset)
+        end
+
+        return ruby_time
+      end
+    end
+  end
+end
+
+Time.send(:include, TimeMonkeyPatch)


### PR DESCRIPTION
After #4 and #6, it implements a way compatible with Ruby's [`Time.strptime`](https://ruby-doc.org/stdlib-2.5.0/libdoc/time/rdoc/Time.html#method-c-strptime), which contains resolving into epoch second.

It's actually moves the `toInstant` method out as a separate class `DefaultRubyTimeResolver`. It is tested/confirmed by Ruby's `test/test_time.rb` with some workarounds.

It comes after #4 and #6. It's totally NOT in a hurry. Can you have a look when you have some time? @sakama (Cc: @muga)