### PR TITLE
Refactor ParserWithContext

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
+++ b/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
@@ -8,7 +8,6 @@ class ParserWithContext {
         this.text = text.toString();
 
         this.pos = 0;
-        this.fail = false;
     }
 
     Parsed parse(final Format format) {
@@ -18,21 +17,7 @@ class ParserWithContext {
             final FormatToken token = tokenWithNext.getToken();
 
             if (!token.isDirective()) {
-                final FormatToken.Immediate stringToken = (FormatToken.Immediate) token;
-                final String str = stringToken.getContent();
-                for (int i = 0; i < str.length(); i++) {
-                    final char c = str.charAt(i);
-                    if (isSpace(c)) {
-                        while (!isEndOfText(text, pos) && isSpace(text.charAt(pos))) {
-                            pos++;
-                        }
-                    } else {
-                        if (isEndOfText(text, pos) || c != text.charAt(pos)) {
-                            fail = true;
-                        }
-                        pos++;
-                    }
-                }
+                this.consumeImmediateString(((FormatToken.Immediate) token).getContent());
             } else {
                 switch (((FormatToken.Directive) token).getFormatDirective()) {
                     // %A - The full weekday name (``Sunday'')
@@ -178,341 +163,341 @@ class ParserWithContext {
             }
         }
 
-        if (fail) {
-            return null;
-        }
-
-        if (text.length() > pos) {
-            builder.setLeftover(text.substring(pos, text.length()));
+        if (this.text.length() > this.pos) {
+            builder.setLeftover(this.text.substring(this.pos, this.text.length()));
         }
 
         return builder.build();
     }
 
+    private void consumeImmediateString(final String immediateString) {
+        for (int i = 0; i < immediateString.length(); i++) {
+            final char c = immediateString.charAt(i);
+            if (isSpace(c)) {
+                while (!isEndOfText(this.text, this.pos) && isSpace(this.text.charAt(this.pos))) {
+                    this.pos++;
+                }
+            } else {
+                if (isEndOfText(this.text, this.pos) || c != this.text.charAt(this.pos)) {
+                    throw new RubyDateTimeParseException(
+                            "Text '" + this.text + "' could not be parsed at index " + this.pos,
+                            this.text,
+                            this.pos);
+                }
+                this.pos++;
+            }
+        }
+    }
+
     private void consumeWeekName(final Parsed.Builder builder) {
         final int dayIndex = findIndexInPatterns(DAY_NAMES);
-        if (dayIndex >= 0) {
-            builder.setDayOfWeekStartingWithSunday0(dayIndex % 7);
-            pos += DAY_NAMES[dayIndex].length();
-        } else {
-            fail = true;
+        if (dayIndex < 0) {
+            throw new RubyDateTimeParseException(
+                    "Text '" + this.text + "' could not be parsed at index " + this.pos,
+                    this.text,
+                    this.pos);
         }
+
+        builder.setDayOfWeekStartingWithSunday0(dayIndex % 7);
+        this.pos += DAY_NAMES[dayIndex].length();
     }
 
     private void consumeMonthOfYearName(final Parsed.Builder builder) {
         final int monIndex = findIndexInPatterns(MONTH_NAMES);
-        if (monIndex >= 0) {
-            builder.setMonthOfYear(monIndex % 12 + 1);
-            pos += MONTH_NAMES[monIndex].length();
-        } else {
-            fail = true;
+        if (monIndex < 0) {
+            throw new RubyDateTimeParseException(
+                    "Text '" + this.text + "' could not be parsed at index " + this.pos,
+                    this.text,
+                    this.pos);
         }
+
+        builder.setMonthOfYear(monIndex % 12 + 1);
+        this.pos += MONTH_NAMES[monIndex].length();
     }
 
     private void consumeCentury(final Parsed.Builder builder, final FormatToken nextToken) {
-        final long cent;
         if (isNumberPattern(nextToken)) {
-            cent = readDigits(2);
+            builder.setCentury((int) this.consumeDigits(2));
         } else {
-            cent = readDigitsMax();
+            builder.setCentury((int) this.consumeDigitsMax());
         }
-        builder.setCentury((int) cent);
     }
 
     private void consumeDayOfMonth(final Parsed.Builder builder) {
-        final long day;
-        if (isBlank(text, pos)) {
-            pos += 1;  // blank
-            day = readDigits(1);
+        final long dayOfMonth;
+        if (isBlank(this.text, this.pos)) {
+            this.pos += 1;  // Blank
+            dayOfMonth = this.consumeDigits(1);
         } else {
-            day = readDigits(2);
+            dayOfMonth = this.consumeDigits(2);
         }
 
-        if (!validRange(day, 1, 31)) {
-            fail = true;
-        }
-        builder.setDayOfMonth((int) day);
+        this.throwIfOutOfRange(dayOfMonth, 1, 31, "invalid day of month");
+        builder.setDayOfMonth((int) dayOfMonth);
     }
 
     private void consumeWeekBasedYearWithCentury(final Parsed.Builder builder, final FormatToken nextToken) {
-        final long year;
         if (isNumberPattern(nextToken)) {
-            year = readDigits(4);
+            builder.setWeekBasedYear((int) this.consumeDigits(4));
         } else {
-            year = readDigitsMax();
+            builder.setWeekBasedYear((int) this.consumeDigitsMax());
         }
-        builder.setWeekBasedYear((int) year);
     }
 
     private void consumeWeekBasedYearWithoutCentury(final Parsed.Builder builder) {
-        final long v = readDigits(2);
-        if (!validRange(v, 0, 99)) {
-            fail = true;
-        }
-        builder.setWeekBasedYearWithoutCentury((int) v);
+        final long weekBasedYearWithoutCentury = this.consumeDigits(2);
+
+        this.throwIfOutOfRange(weekBasedYearWithoutCentury, 0, 99, "invalid year");
+        builder.setWeekBasedYearWithoutCentury((int) weekBasedYearWithoutCentury);
     }
 
     private void consumeHourOfDay(final Parsed.Builder builder) {
-        final long hour;
-        if (isBlank(text, pos)) {
-            pos += 1;  // blank
-            hour = readDigits(1);
+        final long hourOfDay;
+        if (isBlank(this.text, this.pos)) {
+            this.pos += 1;  // Blank
+            hourOfDay = this.consumeDigits(1);
         } else {
-            hour = readDigits(2);
+            hourOfDay = this.consumeDigits(2);
         }
 
-        if (!validRange(hour, 0, 24)) {
-            fail = true;
-        }
-        builder.setHour((int) hour);
+        this.throwIfOutOfRange(hourOfDay, 0, 24, "invalid hour of day");
+        builder.setHour((int) hourOfDay);
     }
 
     private void consumeHourOfAmPm(final Parsed.Builder builder) {
-        final long hour;
-        if (isBlank(text, pos)) {
-            pos += 1; // blank
-            hour = readDigits(1);
+        final long hourOfAmPm;
+        if (isBlank(this.text, this.pos)) {
+            this.pos += 1;  // Blank
+            hourOfAmPm = this.consumeDigits(1);
         } else {
-            hour = readDigits(2);
+            hourOfAmPm = this.consumeDigits(2);
         }
 
-        if (!validRange(hour, 1, 12)) {
-            fail = true;
-        }
-        builder.setHour((int) hour);
+        this.throwIfOutOfRange(hourOfAmPm, 1, 12, "invalid hour of am/pm");
+        builder.setHour((int) hourOfAmPm);
     }
 
     private void consumeDayOfYear(final Parsed.Builder builder) {
-        final long day = readDigits(3);
-        if (!validRange(day, 1, 365)) {
-            fail = true;
-        }
-        builder.setDayOfYear((int) day);
+        final long dayOfYear = this.consumeDigits(3);
+
+        this.throwIfOutOfRange(dayOfYear, 1, 365, "invalid day of year");
+        builder.setDayOfYear((int) dayOfYear);
     }
 
     private void consumeSubsecond(final Parsed.Builder builder, final FormatToken thisToken, final FormatToken nextToken) {
-        boolean negative = false;
-        if (isSign(text, pos)) {
-            negative = text.charAt(pos) == '-';
-            pos++;
+        final boolean negative;
+        if (isSign(this.text, this.pos)) {
+            negative = (this.text.charAt(this.pos) == '-');
+            this.pos++;
+        } else {
+            negative = false;
         }
 
-        final long v;
-        final int initPos = pos;
+        final int initialPosition = this.pos;
+
+        final long value;
         if (isNumberPattern(nextToken)) {
             if (((FormatToken.Directive) thisToken).getFormatDirective() == FormatDirective.MILLI_OF_SECOND) {
-                v = readDigits(3);
+                value = this.consumeDigits(3);
             } else {
-                v = readDigits(9);
+                value = this.consumeDigits(9);
             }
         } else {
-            v = readDigitsMax();
+            value = this.consumeDigitsMax();
         }
 
-        builder.setNanoOfSecond((int) (!negative ? v : -v) * (int) Math.pow(10, 9 - (pos - initPos)));
+        // TODO: Fix cases of subseconds longer than 9.
+        // TODO: Stop using Math.pow(double, double).
+        builder.setNanoOfSecond((int) (!negative ? value : -value) * (int) Math.pow(10, 9 - (this.pos - initialPosition)));
     }
 
     private void consumeMinuteOfHour(final Parsed.Builder builder) {
-        final long min = readDigits(2);
-        if (!validRange(min, 0, 59)) {
-            fail = true;
-        }
-        builder.setMinuteOfHour((int) min);
+        final long minuteOfHour = this.consumeDigits(2);
+
+        this.throwIfOutOfRange(minuteOfHour, 0, 59, "invalid minute of hour");
+        builder.setMinuteOfHour((int) minuteOfHour);
     }
 
     private void consumeMonthOfYear(final Parsed.Builder builder) {
-        final long mon = readDigits(2);
-        if (!validRange(mon, 1, 12)) {
-            fail = true;
-        }
-        builder.setMonthOfYear((int) mon);
+        final long monthOfYear = this.consumeDigits(2);
+
+        this.throwIfOutOfRange(monthOfYear, 1, 12, "invalid month of year");
+        builder.setMonthOfYear((int) monthOfYear);
     }
 
     private void consumeAmPmOfDay(final Parsed.Builder builder) {
         final int meridIndex = findIndexInPatterns(MERID_NAMES);
-        if (meridIndex >= 0) {
-            builder.setAmPmOfDay(meridIndex % 2 == 0 ? 0 : 12);
-            pos += MERID_NAMES[meridIndex].length();
-        } else {
-            fail = true;
+        if (meridIndex < 0) {
+            throw new RubyDateTimeParseException(
+                    "Text '" + this.text + "' could not be parsed at index " + this.pos,
+                    this.text,
+                    this.pos);
         }
+
+        builder.setAmPmOfDay(meridIndex % 2 == 0 ? 0 : 12);
+        this.pos += MERID_NAMES[meridIndex].length();
     }
 
     private void consumeMillisecondSinceEpoch(final Parsed.Builder builder) {
-        boolean negative = false;
-        if (isMinus(text, pos)) {
+        final boolean negative;
+        if (isMinus(this.text, this.pos)) {
             negative = true;
-            pos++;
+            this.pos++;
+        } else {
+            negative = false;
         }
 
-        final long sec = (negative ? -readDigitsMax() : readDigitsMax());
-
-        builder.setInstantMilliseconds(sec);
+        final long absoluteMillisecondSinceEpoch = this.consumeDigitsMax();
+        builder.setInstantMilliseconds(negative ? -absoluteMillisecondSinceEpoch : absoluteMillisecondSinceEpoch);
     }
 
     private void consumeSecondOfMinute(final Parsed.Builder builder) {
-        final long sec = readDigits(2);
-        if (!validRange(sec, 0, 60)) {
-            fail = true;
-        }
-        builder.setSecondOfMinute((int) sec);
+        final long secondOfMinute = this.consumeDigits(2);
+
+        this.throwIfOutOfRange(secondOfMinute, 0, 60, "invalid second of minute");
+        builder.setSecondOfMinute((int) secondOfMinute);
     }
 
     private void consumeSecondSinceEpoch(final Parsed.Builder builder) {
-        boolean negative = false;
-        if (isMinus(text, pos)) {
+        final boolean negative;
+        if (isMinus(this.text, this.pos)) {
             negative = true;
-            pos++;
+            this.pos++;
+        } else {
+            negative = false;
         }
 
-        final long sec = readDigitsMax();
-        builder.setInstantMilliseconds((!negative ? sec : -sec) * 1000);
+        final long absoluteSecondSinceEpoch = this.consumeDigitsMax();
+        builder.setInstantMilliseconds((negative ? -absoluteSecondSinceEpoch : absoluteSecondSinceEpoch) * 1000);
     }
 
     private void consumeWeekOfYear(final Parsed.Builder builder, final FormatToken thisToken) {
-        final long week = readDigits(2);
-        if (!validRange(week, 0, 53)) {
-            fail = true;
-        }
+        final long weekOfYear = this.consumeDigits(2);
+        this.throwIfOutOfRange(weekOfYear, 0, 53, "invalid week of year");
 
         if (((FormatToken.Directive) thisToken).getFormatDirective() == FormatDirective.WEEK_OF_YEAR_STARTING_WITH_SUNDAY) {
-            builder.setWeekOfYearStartingWithSunday((int) week);
+            builder.setWeekOfYearStartingWithSunday((int) weekOfYear);
         } else {
-            builder.setWeekOfYearStartingWithMonday((int) week);
+            builder.setWeekOfYearStartingWithMonday((int) weekOfYear);
         }
     }
 
     private void consumeDayOfWeekStartingWithMonday1(final Parsed.Builder builder) {
-        final long day = readDigits(1);
-        if (!validRange(day, 1, 7)) {
-            fail = true;
-        }
-        builder.setDayOfWeekStartingWithMonday1((int) day);
+        final long dayOfWeek = this.consumeDigits(1);
+
+        this.throwIfOutOfRange(dayOfWeek, 1, 7, "invalid day of week");
+        builder.setDayOfWeekStartingWithMonday1((int) dayOfWeek);
     }
 
     private void consumeWeekOfWeekBasedYear(final Parsed.Builder builder) {
-        final long week = readDigits(2);
-        if (!validRange(week, 1, 53)) {
-            fail = true;
-        }
-        builder.setWeekOfWeekBasedYear((int) week);
+        final long weekOfWeekBasedYear = this.consumeDigits(2);
+
+        this.throwIfOutOfRange(weekOfWeekBasedYear, 1, 53, "invalid week of year");
+        builder.setWeekOfWeekBasedYear((int) weekOfWeekBasedYear);
     }
 
     private void consumeDayOfWeekStartingWithSunday0(final Parsed.Builder builder) {
-        final long day = readDigits(1);
-        if (!validRange(day, 0, 6)) {
-            fail = true;
-        }
-        builder.setDayOfWeekStartingWithSunday0((int) day);
+        final long dayOfWeek = this.consumeDigits(1);
+
+        this.throwIfOutOfRange(dayOfWeek, 0, 6, "invalid week of year");
+        builder.setDayOfWeekStartingWithSunday0((int) dayOfWeek);
     }
 
     private void consumeYearWithCentury(final Parsed.Builder builder, final FormatToken nextToken) {
-        boolean negative = false;
-        if (isSign(text, pos)) {
-            negative = text.charAt(pos) == '-';
-            pos++;
-        }
-
-        final long year;
-        if (isNumberPattern(nextToken)) {
-            year = readDigits(4);
+        final boolean negative;
+        if (isSign(this.text, this.pos)) {
+            negative = (this.text.charAt(this.pos) == '-');
+            this.pos++;
         } else {
-            year = readDigitsMax();
+            negative = false;
         }
 
-        builder.setYear((int) (!negative ? year : -year));
+        final long yearWithCentury;
+        if (isNumberPattern(nextToken)) {
+            yearWithCentury = this.consumeDigits(4);
+        } else {
+            yearWithCentury = this.consumeDigitsMax();
+        }
+
+        builder.setYear((int) (!negative ? yearWithCentury : -yearWithCentury));
     }
 
     private void consumeYearWithoutCentury(final Parsed.Builder builder) {
-        final long y = readDigits(2);
-        if (!validRange(y, 0, 99)) {
-            fail = true;
-        }
-        builder.setYearWithoutCentury((int) y);
+        final long yearWithoutCentury = this.consumeDigits(2);
+
+        this.throwIfOutOfRange(yearWithoutCentury, 0, 99, "invalid year");
+        builder.setYearWithoutCentury((int) yearWithoutCentury);
     }
 
     private void consumeTimeZone(final Parsed.Builder builder) {
-        if (isEndOfText(text, pos)) {
-            fail = true;
-            return;
+        if (isEndOfText(this.text, this.pos)) {
+            throw new RubyDateTimeParseException(
+                    "Text '" + this.text + "' could not be parsed at index " + this.pos,
+                    this.text,
+                    this.pos);
         }
 
-        final Matcher m = ZONE_PARSE_REGEX.matcher(text.substring(pos));
-        if (m.find()) {
-            // zone
-            String zone = text.substring(pos, pos + m.end());
-            builder.setTimeOffset(zone);
-            pos += zone.length();
-        } else {
-            fail = true;
+        final Matcher matcher = ZONE_PARSE_REGEX.matcher(this.text.substring(this.pos));
+        if (!matcher.find()) {
+            throw new RubyDateTimeParseException(
+                    "Text '" + this.text + "' could not be parsed at index " + this.pos,
+                    this.text,
+                    this.pos);
         }
+
+        final String zone = this.text.substring(this.pos, this.pos + matcher.end());
+        builder.setTimeOffset(zone);
+        this.pos += zone.length();
     }
 
-    /**
-     * The method is reimplemented based on read_digits from Ruby v2.3.1's ext/date/date_strptime.c.
-     *
-     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l77">read_digits</a>
-     */
-    private long readDigits(final int len) {
-        char c;
-        long v = 0;
-        final int initPos = pos;
+    private long consumeDigits(final int length) {
+        final int initialPosition = this.pos;
 
-        for (int i = 0; i < len; i++) {
-            if (isEndOfText(text, pos)) {
+        long result = 0L;
+        for (int i = 0; i < length; i++) {
+            if (isEndOfText(this.text, this.pos)) {
                 break;
             }
 
-            c = text.charAt(pos);
+            final char c = text.charAt(this.pos);
             if (!isDigit(c)) {
                 break;
-            } else {
-                v = v * 10 + toInt(c);
             }
-            pos += 1;
+            result = result * 10 + toInt(c);
+            this.pos += 1;
         }
 
-        if (pos == initPos) {
-            fail = true;
+        if (this.pos == initialPosition) {
+            throw new RubyDateTimeParseException(
+                    "Text '" + this.text + "' could not be parsed at index " + this.pos + ": no digits",
+                    this.text,
+                    this.pos);
         }
 
-        return v;
+        return result;
     }
 
-    /**
-     * The method is reimplemented based on READ_DIGITS_MAX from Ruby v2.3.1's ext/date/date_strptime.c.
-     *
-     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l137">READ_DIGITS_MAX</a>
-     */
-    private long readDigitsMax() {
-        return readDigits(Integer.MAX_VALUE);
+    private long consumeDigitsMax() {
+        return this.consumeDigits(Integer.MAX_VALUE);
     }
 
-    /**
-     * Returns -1 if text doesn't match with patterns.
-     */
     private int findIndexInPatterns(final String[] patterns) {
-        if (isEndOfText(text, pos)) {
+        if (isEndOfText(text, this.pos)) {
             return -1;
         }
 
         for (int i = 0; i < patterns.length; i++) {
             final String pattern = patterns[i];
-            final int len = pattern.length();
-            if (!isEndOfText(text, pos + len - 1)
-                    && pattern.equalsIgnoreCase(text.substring(pos, pos + len))) { // strncasecmp
+            final int length = pattern.length();
+            if (!isEndOfText(this.text, this.pos + length - 1)
+                        && pattern.equalsIgnoreCase(this.text.substring(this.pos, this.pos + length))) {
                 return i;
             }
         }
 
-        return -1; // text doesn't match at any patterns.
+        return -1;  // Case that text doesn't match at any patterns.
     }
 
-    /**
-     * The method is reimplemented based on num_pattern_p from Ruby v2.3.1's ext/date/date_strptime.c.
-     *
-     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l58">num_pattern_p</a>
-     */
     private static boolean isNumberPattern(final FormatToken token) {
         if (token == null) {
             return false;
@@ -525,47 +510,49 @@ class ParserWithContext {
         }
     }
 
-    /**
-     * The method is reimplemented based on valid_range_p from Ruby v2.3.1's ext/date/date_strptime.c.
-     *
-     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l139">valid_range_p</a>
-     */
-    private static boolean validRange(long v, int lower, int upper) {
-        return lower <= v && v <= upper;
+    private void throwIfOutOfRange(final long value, final int lower, final int upper, final String message) {
+        if (lower > value || value > upper) {
+            throw new RubyDateTimeParseException(
+                    "Text '" + this.text + "' could not be parsed at index " + this.pos + ": " + message,
+                    this.text,
+                    this.pos);
+        }
     }
 
-    private static boolean isSpace(char c) {
+    private static boolean isSpace(final char c) {
         return c == ' ' || c == '\t' || c == '\n' || c == '\u000b' || c == '\f' || c == '\r';
     }
 
-    private static boolean isDigit(char c) {
+    private static boolean isDigit(final char c) {
         return '0' <= c && c <= '9';
     }
 
-    private static boolean isEndOfText(String text, int pos) {
+    private static boolean isEndOfText(final String text, final int pos) {
         return pos >= text.length();
     }
 
-    private static boolean isSign(String text, int pos) {
+    private static boolean isSign(final String text, final int pos) {
         return !isEndOfText(text, pos) && (text.charAt(pos) == '+' || text.charAt(pos) == '-');
     }
 
-    private static boolean isMinus(String text, int pos) {
+    private static boolean isMinus(final String text, final int pos) {
         return !isEndOfText(text, pos) && text.charAt(pos) == '-';
     }
 
-    private static boolean isBlank(String text, int pos) {
+    private static boolean isBlank(final String text, final int pos) {
         return !isEndOfText(text, pos) && text.charAt(pos) == ' ';
     }
 
-    private static int toInt(char c) {
+    private static int toInt(final char c) {
         return c - '0';
     }
 
     /**
-     * The regular expression is reimplemented from Ruby v2.3.1's ext/date/date_strptime.c.
+     * Regular expression that matches time zones.
      *
-     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/ext/date/date_strptime.c?view=markup#l571">pat_source</a>
+     * <p>It comes from Ruby v2.5.1.
+     *
+     * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_5_1/ext/date/date_strptime.c?view=markup#l571">ext/date/date_strptime.c</a>
      */
     private static final Pattern ZONE_PARSE_REGEX =
         Pattern.compile("\\A("
@@ -593,5 +580,4 @@ class ParserWithContext {
     private final String text;
 
     private int pos;
-    private boolean fail;
 }

--- a/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
+++ b/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
@@ -53,6 +53,17 @@ public class TestRubyDateTimeFormatterParse {
     }
 
     @Test
+    public void testSubseconds() throws RubyTimeResolveException {
+        assertParsedTime("2007-08-01T00:00:00.777777777",
+                         "%Y-%m-%dT%H:%M:%S.%N",
+                         Instant.ofEpochSecond(1185926400L, 777777777));
+        // TODO: Fix it.
+        // assertParsedTime("2007-08-01T00:00:00.77777777777777",
+        //                  "%Y-%m-%dT%H:%M:%S.%N",
+        //                  Instant.ofEpochSecond(1185926400L, 777777777));
+    }
+
+    @Test
     public void testDateTimeFromInstant() throws RubyTimeResolveException {
         final RubyDateTimeFormatter formatter = RubyDateTimeFormatter.ofPattern("%Q.%N");
         final TemporalAccessor parsed = formatter.parseUnresolved("1500000000456.111111111");

--- a/src/test/resources/date_monkey_patch.rb
+++ b/src/test/resources/date_monkey_patch.rb
@@ -8,9 +8,13 @@ module DateMonkeyPatch
       def _strptime(str, fmt='%F')
         formatter = Java::org.embulk.util.rubytime.RubyDateTimeFormatter.ofPattern(fmt)
 
-        parsed = formatter.parseUnresolved(str)
-        if parsed.nil?
+        begin
+          parsed = formatter.parseUnresolved(str)
+        rescue Java::org.embulk.util.rubytime.RubyDateTimeParseException
           return nil
+        end
+        if parsed.nil?
+          raise 'RubyDateTimeFormatter#parseUnresolved returned null unexpectedly.'
         end
 
         map = parsed.query(Java::org.embulk.util.rubytime.ParsedElementsQuery.of(

--- a/src/test/resources/time_monkey_patch.rb
+++ b/src/test/resources/time_monkey_patch.rb
@@ -8,9 +8,13 @@ module TimeMonkeyPatch
       def strptime(date, format)
         formatter = Java::org.embulk.util.rubytime.RubyDateTimeFormatter.ofPattern(format)
 
-        parsed = formatter.parseUnresolved(date)
-        if parsed.nil?
+        begin
+          parsed = formatter.parseUnresolved(date)
+        rescue Java::org.embulk.util.rubytime.RubyDateTimeParseException
           return nil
+        end
+        if parsed.nil?
+          raise 'RubyDateTimeFormatter#parseUnresolved returned null unexpectedly.'
         end
 
         resolver = Java::org.embulk.util.rubytime.DefaultRubyTimeResolver.of()


### PR DESCRIPTION
It refactors `ParserWithContext`.

* The first commit (a1f0232e15ea371050ad3a497bf8bc3306910abf) breaks down the large `parse` method into smaller consumer methods.
* The second commit (8d6c7a155aa24f24bef62b42ff67bca1c91cf0e5) refactors each consumer method, and change them to throw `RubyDateTimeParseException` in error cases.

@sakama @kamatama41 Can you have a look when you have time?