### PR TITLE
Cleanup visibility, mutability, extendability, and Javadoc of classes

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/DateZones.java
+++ b/src/main/java/org/embulk/util/rubytime/DateZones.java
@@ -35,7 +35,7 @@ package org.embulk.util.rubytime;
  * <li>Offset with too long a fraction part (e.g. "UTC+10.111111111111") is not accepted. Exception is thrown instead.
  * </ul>
  */
-public final class DateZones {
+final class DateZones {
     private DateZones() {
         // No instantiation.
     }

--- a/src/main/java/org/embulk/util/rubytime/DefaultRubyTimeResolver.java
+++ b/src/main/java/org/embulk/util/rubytime/DefaultRubyTimeResolver.java
@@ -13,14 +13,12 @@ import java.time.temporal.TemporalQuery;
 import java.time.temporal.ValueRange;
 
 /**
- * Resolves date/time from TemporalAccessor parsed by RubyDateTimeFormatter by the same rule as Ruby's Time.strptime.
+ * Resolves date-time from {@code java.time.temporal.TemporalAccessor} parsed by {@code RubyDateTimeFormatter} by the same rule as Ruby's {@code Time.strptime}.
  *
  * <p>A difference from Ruby's {@code Time.strptime} is that it does not consider "now" and local time zone.
  * If the given zone is neither numerical nor predefined textual time zones, it returns defaultZoneOffset then.
  *
  * <p>Ruby's {@code Time} class implements a proleptic Gregorian calendar and has no concept of calendar reform.
- *
- * @see <a href="https://docs.ruby-lang.org/en/2.5.0/DateTime.html#class-DateTime-label-When+should+you+use+DateTime+and+when+should+you+use+Time-3F">When should you use DateTime and when should you use Time?</a>
  *
  * <p>Epoch seconds (%s) and epoch milliseconds (%Q) are prioritized over calendar date/time although
  * fraction part (%L/%N) is added to the epoch seconds/milliseconds.
@@ -57,9 +55,11 @@ import java.time.temporal.ValueRange;
  *
  * <p>The resolver is reimplemented based on {@code Time.strptime} of Ruby v2.5.0.
  *
+ * @see <a href="https://docs.ruby-lang.org/en/2.5.0/DateTime.html#class-DateTime-label-When+should+you+use+DateTime+and+when+should+you+use+Time-3F">When should you use DateTime and when should you use Time?</a>
+ *
  * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_5_0/lib/time.rb?view=markup#l431">Time.strptime</a>
  */
-public class DefaultRubyTimeResolver implements RubyTimeResolver {
+public final class DefaultRubyTimeResolver implements RubyDateTimeResolver {
     private DefaultRubyTimeResolver(
             final boolean acceptsEmpty,
             final ZoneOffset defaultOffset,

--- a/src/main/java/org/embulk/util/rubytime/Format.java
+++ b/src/main/java/org/embulk/util/rubytime/Format.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * Represents a Ruby-compatible date-time format.
  */
-class Format implements Iterable<Format.TokenWithNext> {
+final class Format implements Iterable<Format.TokenWithNext> {
     private Format(final List<FormatToken> compiledPattern) {
         this.compiledPattern = Collections.unmodifiableList(compiledPattern);
     }

--- a/src/main/java/org/embulk/util/rubytime/FormatToken.java
+++ b/src/main/java/org/embulk/util/rubytime/FormatToken.java
@@ -6,7 +6,7 @@ package org.embulk.util.rubytime;
 abstract class FormatToken {
     abstract boolean isDirective();
 
-    static class Directive extends FormatToken {
+    static final class Directive extends FormatToken {
         Directive(final FormatDirective formatDirective) {
             this.formatDirective = formatDirective;
         }
@@ -37,7 +37,7 @@ abstract class FormatToken {
         private final FormatDirective formatDirective;
     }
 
-    static class Immediate extends FormatToken {
+    static final class Immediate extends FormatToken {
         Immediate(final char character) {
             this.string = "" + character;
         }

--- a/src/main/java/org/embulk/util/rubytime/LegacyEmbulkZones.java
+++ b/src/main/java/org/embulk/util/rubytime/LegacyEmbulkZones.java
@@ -45,7 +45,7 @@ import java.util.Map;
  *
  * <p>If the given zone is not recognized above, it is fallback to {@code org.embulk.util.rubytime.DateZones}.
  */
-public class LegacyEmbulkZones {
+final class LegacyEmbulkZones {
     private LegacyEmbulkZones() {
         // No instantiation.
     }

--- a/src/main/java/org/embulk/util/rubytime/Parsed.java
+++ b/src/main/java/org/embulk/util/rubytime/Parsed.java
@@ -1,6 +1,5 @@
 package org.embulk.util.rubytime;
 
-import java.math.BigDecimal;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.OffsetDateTime;

--- a/src/main/java/org/embulk/util/rubytime/ParsedElementsQuery.java
+++ b/src/main/java/org/embulk/util/rubytime/ParsedElementsQuery.java
@@ -12,9 +12,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Queries to provide Maps of parsed elements, which are analogous to Ruby hashes by Date._strptime.
+ * Queries to retrieve a Map of parsed elements.
+ *
+ * <p>The {@code Map} of parsed elements is analogous to a hash returned from {@code Date._strptime} like below.
+ *
+ * <pre>{@code
+ * {:year=>2001, :mon=>2, :mday=>3}
+ * }</pre>
+ *
+ * @see <a href="https://ruby-doc.org/stdlib-2.5.1/libdoc/date/rdoc/Date.html#method-c-_strptime">Date._strptime</a>
  */
-public class ParsedElementsQuery<T> implements TemporalQuery<Map<T, Object>> {
+public final class ParsedElementsQuery<T> implements TemporalQuery<Map<T, Object>> {
     public static interface FractionConverter {
         Object convertFraction(int seconds, int nanoOfSecond);
     }

--- a/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
+++ b/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
@@ -3,7 +3,7 @@ package org.embulk.util.rubytime;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-class ParserWithContext {
+final class ParserWithContext {
     ParserWithContext(final CharSequence text) {
         this.text = text.toString();
 

--- a/src/main/java/org/embulk/util/rubytime/RubyChronoField.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyChronoField.java
@@ -9,6 +9,9 @@ import java.time.temporal.TemporalUnit;
 import java.time.temporal.ValueRange;
 import java.util.Locale;
 
+/**
+ * A Ruby-specific set of temporal fields.
+ */
 public final class RubyChronoField {
     public static final TemporalField WEEK_BASED_YEAR = Field.WEEK_BASED_YEAR;
 

--- a/src/main/java/org/embulk/util/rubytime/RubyDateTimeFormatter.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyDateTimeFormatter.java
@@ -5,26 +5,44 @@ import java.time.temporal.TemporalAccessor;
 /**
  * Formatter for printing and parsing date-time objects in a way similar to Ruby's Time.strptime.
  *
- * <p>Its interface is designed to be similar to {@code java.time.DateTimeFormatter}.
- *
- * <p>Note that epoch milliseconds (%Q) and epoch seconds (%s) are considered equally.
- *
- * <code>
- * irb(main):002:0> Date._strptime("123456789 12849124", "%Q %s")
- * => {:seconds=>12849124}
- * irb(main):003:0> Date._strptime("123456789 12849124", "%s %Q")
- * => {:seconds=>(3212281/250)}
- * </code>
+ * <p>Methods in this class are designed to be similar to {@code java.time.DateTimeFormatter}.
  */
 public final class RubyDateTimeFormatter {
     private RubyDateTimeFormatter(final Format format) {
         this.format = format;
     }
 
+    /**
+     * Creates a formatter using the specified pattern.
+     *
+     * @param pattern  the pattern to use, not null
+     *
+     * @return the formatter based on the pattern, not null
+     */
     public static RubyDateTimeFormatter ofPattern(final String pattern) {
         return new RubyDateTimeFormatter(Format.compile(pattern));
     }
 
+    /**
+     * Parses the text using this formatter, without resolving the result, intended for advanced use cases.
+     *
+     * <p>Parsing is implemented as a two-phase operation as {@code java.time.DateTimeFormatter#parseUnresolved} does.
+     *
+     * <p>Note that epoch milliseconds (%Q) and epoch seconds (%s) are considered equally.
+     *
+     * <pre>{@code
+     * irb(main):002:0> Date._strptime("123456789 12849124", "%Q %s")
+     * => {:seconds=>12849124}
+     * irb(main):003:0> Date._strptime("123456789 12849124", "%s %Q")
+     * => {:seconds=>(3212281/250)}
+     * }</pre>
+     *
+     * @param text  the text to parse, not null
+     *
+     * @return the parsed text
+     *
+     * @throws RubyDateTimeParseException  if the parse results in an error
+     */
     public TemporalAccessor parseUnresolved(final String text) {
         return new ParserWithContext(text).parse(this.format);
     }

--- a/src/main/java/org/embulk/util/rubytime/RubyDateTimeParseException.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyDateTimeParseException.java
@@ -2,6 +2,9 @@ package org.embulk.util.rubytime;
 
 import java.time.format.DateTimeParseException;
 
+/**
+ * An exception thrown when an error occurs during parsing a date-time string by RubyDateTimeFormatter.
+ */
 public class RubyDateTimeParseException extends DateTimeParseException {
     public RubyDateTimeParseException(
             final String message, final CharSequence parsedData, final int errorIndex) {

--- a/src/main/java/org/embulk/util/rubytime/RubyDateTimeResolver.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyDateTimeResolver.java
@@ -3,8 +3,8 @@ package org.embulk.util.rubytime;
 import java.time.temporal.TemporalAccessor;
 
 /**
- * Resolves TemporalAccessor parsed by RubyDateTimeFormatter into a meaningful date-time object.
+ * Resolves {@code java.time.temporal.TemporalAccessor} parsed by {@code RubyDateTimeFormatter} into a meaningful date-time object.
  */
-public interface RubyTimeResolver {
+public interface RubyDateTimeResolver {
     TemporalAccessor resolve(TemporalAccessor source) throws RubyTimeResolveException;
 }

--- a/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
@@ -4,7 +4,10 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQuery;
 
-public class RubyTemporalQueries {
+/**
+ * Ruby-specific implementations of {@code java.time.temporal.TemporalQuery}.
+ */
+public final class RubyTemporalQueries {
     private RubyTemporalQueries() {
         // No instantiation.
     }

--- a/src/main/java/org/embulk/util/rubytime/TimeZones.java
+++ b/src/main/java/org/embulk/util/rubytime/TimeZones.java
@@ -40,7 +40,7 @@ import java.util.Locale;
  * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup">lib/time.rb</a>
  * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/COPYING?view=markup">COPYING</a>
  */
-public class TimeZones {
+final class TimeZones {
     private TimeZones() {
         // No instantiation.
     }

--- a/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
+++ b/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
@@ -68,7 +68,7 @@ public class TestRubyDateTimeFormatterParse {
         final RubyDateTimeFormatter formatter = RubyDateTimeFormatter.ofPattern("%Q.%N");
         final TemporalAccessor parsed = formatter.parseUnresolved("1500000000456.111111111");
 
-        final RubyTimeResolver resolver = DefaultRubyTimeResolver.of();
+        final RubyDateTimeResolver resolver = DefaultRubyTimeResolver.of();
         final TemporalAccessor resolved = resolver.resolve(parsed);
 
         final OffsetDateTime datetime = OffsetDateTime.from(resolved);
@@ -88,7 +88,7 @@ public class TestRubyDateTimeFormatterParse {
         final RubyDateTimeFormatter formatter = RubyDateTimeFormatter.ofPattern(format);
         final TemporalAccessor parsed = formatter.parseUnresolved(string);
 
-        final RubyTimeResolver resolver = DefaultRubyTimeResolver.of();
+        final RubyDateTimeResolver resolver = DefaultRubyTimeResolver.of();
         final TemporalAccessor resolved = resolver.resolve(parsed);
 
         final Instant actualInstant = Instant.from(resolved);


### PR DESCRIPTION
Another refactoring.

* Only classes that need to be `public` are now `public`.
* Only classes that need to be non-`final` are not non-`final` (extendable).
* All `public` classes have Javadoc.

@sakama @kamatama41 Can you have a look when you have time?