### PR TITLE
Fix and test very long matches with digits

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
+++ b/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
@@ -268,7 +268,7 @@ class ParserWithContext {
     }
 
     private void consumeDayOfYear(final Parsed.Builder builder) {
-        builder.setDayOfYear(this.consumeDigitsInInt(3, 1, 365, "invalid day of year"));
+        builder.setDayOfYear(this.consumeDigitsInInt(3, 1, 366, "invalid day of year"));
     }
 
     private void consumeSubsecond(final Parsed.Builder builder, final FormatToken thisToken, final FormatToken nextToken) {

--- a/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
+++ b/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
@@ -53,14 +53,33 @@ public class TestRubyDateTimeFormatterParse {
     }
 
     @Test
+    public void testLarge() throws RubyTimeResolveException {
+        assertParsedTime("-999999999-01-01T00:00:00", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(-31557014135596800L, 0));
+        // assertFailParse("-1000000000-12-31T23:59:59", "%Y-%m-%dT%H:%M:%S");
+        assertParsedTime("999999999-12-31T23:59:59", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(31556889832780799L, 0));
+        // assertFailParse("1000000000-01-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+
+        assertParsedTime("9223372036854775", "%s", Instant.ofEpochSecond(9223372036854775L, 0));
+        // assertFailParse("9223372036854776", "%s");
+        assertParsedTime("-9223372036854775", "%s", Instant.ofEpochSecond(-9223372036854775L, 0));
+        // assertFailParse("-9223372036854776", "%s");
+
+        assertParsedTime("9223372036854775807", "%Q", Instant.ofEpochSecond(9223372036854775L, 807000000));
+        // assertFailParse("9223372036854775808", "%Q");
+        assertParsedTime("-9223372036854775807", "%Q", Instant.ofEpochSecond(-9223372036854776L, 193000000));
+        // assertFailParse("-9223372036854775808", "%Q");
+    }
+
+    @Test
     public void testSubseconds() throws RubyTimeResolveException {
+        // assertFailParse("2007-08-01T00:00:00.", "%Y-%m-%dT%H:%M:%S.%N");
+        // assertFailParse("2007-08-01T00:00:00.-777777777", "%Y-%m-%dT%H:%M:%S.%N");
         assertParsedTime("2007-08-01T00:00:00.777777777",
                          "%Y-%m-%dT%H:%M:%S.%N",
                          Instant.ofEpochSecond(1185926400L, 777777777));
-        // TODO: Fix it.
-        // assertParsedTime("2007-08-01T00:00:00.77777777777777",
-        //                  "%Y-%m-%dT%H:%M:%S.%N",
-        //                  Instant.ofEpochSecond(1185926400L, 777777777));
+        assertParsedTime("2007-08-01T00:00:00.77777777777777",
+                         "%Y-%m-%dT%H:%M:%S.%N",
+                         Instant.ofEpochSecond(1185926400L, 777777777));
     }
 
     @Test


### PR DESCRIPTION
It's a fix (with restructuring some methods) on very long matches with digits. For example,

* Long year (e.g. `999999999-12-31T23:59:59`)
* Long epoch second (e.g. `9223372036854775`)
* Long fraction part of second (e.g. `2007-08-01T00:00:00.777777777777777777777`)

@sakama @kamatama41 Can you have a look when you have time?