### PR TITLE
Revise INSTANT_MILLIS to INSTANT_SECONDS and NANO_OF_INSTANT_SECONDS

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/FormatDirective.java
+++ b/src/main/java/org/embulk/util/rubytime/FormatDirective.java
@@ -91,8 +91,8 @@ enum FormatDirective {
 
     // Seconds since the Epoch:
 
-    SECOND_SINCE_EPOCH(true, 's'),
-    MILLISECOND_SINCE_EPOCH(false, 'Q'),  // TODO: Revisit this "%Q" is not a numeric pattern?
+    SECONDS_SINCE_EPOCH(true, 's'),
+    MILLISECONDS_SINCE_EPOCH(false, 'Q'),  // TODO: Revisit this "%Q" is not a numeric pattern?
 
     // Recurred:
 

--- a/src/main/java/org/embulk/util/rubytime/Parsed.java
+++ b/src/main/java/org/embulk/util/rubytime/Parsed.java
@@ -54,7 +54,8 @@ final class Parsed implements TemporalAccessor {
             final int nanoOfSecond,
             final int minuteOfHour,
             final int monthOfYear,
-            final long instantMilliseconds,
+            final long secondsSinceEpoch,
+            final int nanoOfSecondsSinceEpoch,
             final int secondOfMinute,
             final int weekOfYearStartingWithSunday,
             final int weekOfYearStartingWithMonday,
@@ -95,8 +96,11 @@ final class Parsed implements TemporalAccessor {
         if (monthOfYear > Integer.MIN_VALUE) {
             this.chronoFieldValues.put(ChronoField.MONTH_OF_YEAR, (long) monthOfYear);
         }
-        if (instantMilliseconds > Long.MIN_VALUE) {
-            this.rubyChronoFieldValues.put(RubyChronoFields.Field.INSTANT_MILLIS, instantMilliseconds);
+        if (secondsSinceEpoch > Long.MIN_VALUE) {
+            this.chronoFieldValues.put(ChronoField.INSTANT_SECONDS, secondsSinceEpoch);
+        }
+        if (nanoOfSecondsSinceEpoch > Integer.MIN_VALUE) {
+            this.rubyChronoFieldValues.put(RubyChronoFields.Field.NANO_OF_INSTANT_SECONDS, (long) nanoOfSecondsSinceEpoch);
         }
         if (secondOfMinute > Integer.MIN_VALUE) {
             this.chronoFieldValues.put(ChronoField.SECOND_OF_MINUTE, (long) secondOfMinute);
@@ -148,7 +152,8 @@ final class Parsed implements TemporalAccessor {
             this.minuteOfHour = Integer.MIN_VALUE;
             this.monthOfYear = Integer.MIN_VALUE;
             this.ampmOfDay = Integer.MIN_VALUE;
-            this.instantMilliseconds = Long.MIN_VALUE;
+            this.secondsSinceEpoch = Long.MIN_VALUE;
+            this.nanoOfSecondsSinceEpoch = Integer.MIN_VALUE;
             this.secondOfMinute = Integer.MIN_VALUE;
             this.weekOfYearStartingWithSunday = Integer.MIN_VALUE;
             this.weekOfYearStartingWithMonday = Integer.MIN_VALUE;
@@ -212,7 +217,8 @@ final class Parsed implements TemporalAccessor {
                     this.nanoOfSecond,
                     this.minuteOfHour,
                     this.monthOfYear,
-                    this.instantMilliseconds,
+                    this.secondsSinceEpoch,
+                    this.nanoOfSecondsSinceEpoch,
                     (this.secondOfMinute == 60 ? 59 : this.secondOfMinute),
                     this.weekOfYearStartingWithSunday,
                     this.weekOfYearStartingWithMonday,
@@ -415,16 +421,37 @@ final class Parsed implements TemporalAccessor {
         }
 
         /**
-         * Sets second since the epoch.
+         * Sets seconds since the epoch.
          *
          * <ul>
          * <li> Ruby Date._strptime hash key corresponding: seconds
-         * <li> Ruby strptime directive specifier related: %Q, %s
-         * <li> java.time.temporal: RubyChronoFields.INSTANT_MILLIS
+         * <li> Ruby strptime directive specifier related: %s
+         * <li> java.time.temporal: ChronoField.INSTANT_SECONDS
          * </ul>
          */
-        Builder setInstantMilliseconds(final long instantMilliseconds) {
-            this.instantMilliseconds = instantMilliseconds;
+        Builder setSecondsSinceEpoch(final long secondsSinceEpoch) {
+            this.secondsSinceEpoch = secondsSinceEpoch;
+            this.nanoOfSecondsSinceEpoch = 0;
+            return this;
+        }
+
+        /**
+         * Sets milliseconds since the epoch.
+         *
+         * <ul>
+         * <li> Ruby Date._strptime hash key corresponding: seconds
+         * <li> Ruby strptime directive specifier related: %Q
+         * <li> java.time.temporal: ChronoField.INSTANT_SECONDS, RubyChronoFields.MILLI_OF_INSTANT_SECONDS
+         * </ul>
+         */
+        Builder setMillisecondsSinceEpoch(final long millisecondsSinceEpoch) {
+            if (millisecondsSinceEpoch >= 0) {
+                this.secondsSinceEpoch = millisecondsSinceEpoch / 1000L;
+                this.nanoOfSecondsSinceEpoch = ((int) (millisecondsSinceEpoch % 1000L)) * 1000_000;
+            } else {
+                this.secondsSinceEpoch = millisecondsSinceEpoch / 1000L - 1;
+                this.nanoOfSecondsSinceEpoch = ((int) (millisecondsSinceEpoch % 1000L) + 1000) * 1000_000;
+            }
             return this;
         }
 
@@ -624,7 +651,8 @@ final class Parsed implements TemporalAccessor {
         private int minuteOfHour;
         private int monthOfYear;
         private int ampmOfDay;
-        private long instantMilliseconds;
+        private long secondsSinceEpoch;
+        private int nanoOfSecondsSinceEpoch;
         private int secondOfMinute;
         private int weekOfYearStartingWithSunday;
         private int weekOfYearStartingWithMonday;

--- a/src/main/java/org/embulk/util/rubytime/RubyChronoFields.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyChronoFields.java
@@ -39,9 +39,9 @@ public final class RubyChronoFields {
     public static final TemporalField WEEK_BASED_YEAR = Field.WEEK_BASED_YEAR;
 
     /**
-     * The instant epoch-milliseconds.
+     * The nano-of-instant epoch-seconds.
      */
-    public static final TemporalField INSTANT_MILLIS = Field.INSTANT_MILLIS;
+    public static final TemporalField NANO_OF_INSTANT_SECONDS = Field.NANO_OF_INSTANT_SECONDS;
 
     /**
      * The week number of the year, with the week starting with Sunday (00..53).
@@ -76,11 +76,11 @@ public final class RubyChronoFields {
                 ValueRange.of(Year.MIN_VALUE, Year.MAX_VALUE),
                 true,
                 false),
-        INSTANT_MILLIS(
-                "InstantMillis",
-                ChronoUnit.MILLIS,
-                ChronoUnit.FOREVER,
-                ValueRange.of(Long.MIN_VALUE, Long.MAX_VALUE),
+        NANO_OF_INSTANT_SECONDS(
+                "NanoOfInstantSeconds",
+                ChronoUnit.NANOS,
+                ChronoUnit.SECONDS,
+                ValueRange.of(0, 999_999_999),
                 false,
                 true),
         WEEK_OF_YEAR_STARTING_WITH_SUNDAY(

--- a/src/main/java/org/embulk/util/rubytime/RubyDateTimeParsedElementsQuery.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyDateTimeParsedElementsQuery.java
@@ -165,7 +165,7 @@ public final class RubyDateTimeParsedElementsQuery<T> implements TemporalQuery<M
         builder.putSecFraction();
         builder.put("min", ChronoField.MINUTE_OF_HOUR);
         builder.put("mon", ChronoField.MONTH_OF_YEAR);
-        builder.putInstantMillisecond();
+        builder.putInstantSeconds();
         builder.putSecondOfMinute();
         builder.put("wnum0", RubyChronoFields.WEEK_OF_YEAR_STARTING_WITH_SUNDAY);
         builder.put("wnum1", RubyChronoFields.WEEK_OF_YEAR_STARTING_WITH_MONDAY);
@@ -230,17 +230,21 @@ public final class RubyDateTimeParsedElementsQuery<T> implements TemporalQuery<M
             }
         }
 
-        private void putInstantMillisecond() {
-            if (this.temporal.isSupported(RubyChronoFields.INSTANT_MILLIS)) {
-                final long instantMillisecond = this.temporal.getLong(RubyChronoFields.INSTANT_MILLIS);
-                final int instantSecond = (int) (instantMillisecond / 1000);
-                final int nanoOfInstantSecond = (int) (instantMillisecond % 1000) * 1_000_000;
-                if (nanoOfInstantSecond == 0) {
-                    this.built.put(this.mapKeyConverter.convertMapKey("seconds"), instantSecond);
+        private void putInstantSeconds() {
+            if (this.temporal.isSupported(ChronoField.INSTANT_SECONDS)) {
+                final long instantSeconds = this.temporal.getLong(ChronoField.INSTANT_SECONDS);
+                final int nanoOfInstantSeconds;
+                if (this.temporal.isSupported(ChronoField.INSTANT_SECONDS)) {
+                    nanoOfInstantSeconds = this.temporal.get(RubyChronoFields.NANO_OF_INSTANT_SECONDS);
+                } else {
+                    nanoOfInstantSeconds = 0;
+                }
+                if (nanoOfInstantSeconds == 0) {
+                    this.built.put(this.mapKeyConverter.convertMapKey("seconds"), instantSeconds);
                 } else {
                     this.built.put(this.mapKeyConverter.convertMapKey("seconds"),
                                    this.decimalFractionConverterInner.convertDecimalFraction(
-                                           instantSecond, nanoOfInstantSecond));
+                                           instantSeconds, nanoOfInstantSeconds));
                 }
             }
         }

--- a/src/test/java/org/embulk/util/rubytime/TestFormat.java
+++ b/src/test/java/org/embulk/util/rubytime/TestFormat.java
@@ -77,8 +77,8 @@ public class TestFormat {
         testFormat("%U", FormatDirective.WEEK_OF_YEAR_STARTING_WITH_SUNDAY.toTokens());
         testFormat("%W", FormatDirective.WEEK_OF_YEAR_STARTING_WITH_MONDAY.toTokens());
 
-        testFormat("%s", FormatDirective.SECOND_SINCE_EPOCH.toTokens());
-        testFormat("%Q", FormatDirective.MILLISECOND_SINCE_EPOCH.toTokens());
+        testFormat("%s", FormatDirective.SECONDS_SINCE_EPOCH.toTokens());
+        testFormat("%Q", FormatDirective.MILLISECONDS_SINCE_EPOCH.toTokens());
     }
 
     @Test

--- a/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
+++ b/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import org.junit.jupiter.api.Test;
 
@@ -32,10 +33,12 @@ public class TestRubyDateTimeFormatterParse {
     @Test
     public void testMultipleEpochs() {
         final TemporalAccessor parsed1 = strptime("123456789 12849124", "%Q %s");
-        assertEquals(1000L * 12849124L, parsed1.getLong(RubyChronoFields.Field.INSTANT_MILLIS));
+        assertEquals(12849124L, parsed1.getLong(ChronoField.INSTANT_SECONDS));
+        assertEquals(0, parsed1.get(RubyChronoFields.NANO_OF_INSTANT_SECONDS));
 
         final TemporalAccessor parsed2 = strptime("123456789 12849124", "%s %Q");
-        assertEquals(1000L * 3212281L / 250L, parsed2.getLong(RubyChronoFields.Field.INSTANT_MILLIS));
+        assertEquals(12849L, parsed2.getLong(ChronoField.INSTANT_SECONDS));
+        assertEquals(124000000, parsed2.get(RubyChronoFields.NANO_OF_INSTANT_SECONDS));
     }
 
     @Test

--- a/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeParsedElementsQuery.java
+++ b/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeParsedElementsQuery.java
@@ -29,7 +29,7 @@ public class TestRubyDateTimeParsedElementsQuery {
     @Test
     public void test() {
         final Parsed.Builder builder = Parsed.builder("foo");
-        builder.setInstantMilliseconds(123456789);
+        builder.setMillisecondsSinceEpoch(123456789);
         builder.setHour(11);
         builder.setDayOfYear(92);
         builder.setWeekBasedYear(1998);


### PR DESCRIPTION
It's almost the last update before releasing this as a library. Can you have a look? @sakama @kamatama41

----

Relatively big change.

Epoch seconds were represented by milliseconds in single `long` because Ruby's `Time.strptime` has `%Q`. But, `Instant.MAX` in milliseconds is larger than `Long.MAX_VALUE` unfortunately.

Then, decided to represent epoch seconds split by an integer part and a fraction part.