### PR TITLE
Bump to v0.2.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: "signing"
 
 group = "org.embulk"
 archivesBaseName = "${project.name}"
-version = "0.1.1-SNAPSHOT"
+version = "0.2.0-SNAPSHOT"
 description "Almost Ruby-compatible date-time processor for Embulk and Embulk plugins"
 
 repositories {


### PR DESCRIPTION
Updating the version to v0.2.0 -- planned to break the backward compatibility in #39 (WIP).