### PR TITLE
Apply a time offset in a correct manner

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/DefaultRubyTimeResolver.java
+++ b/src/main/java/org/embulk/util/rubytime/DefaultRubyTimeResolver.java
@@ -352,28 +352,28 @@ final class DefaultRubyTimeResolver extends RubyDateTimeResolver {
         if (offset < 0) {
             offset = -offset;
 
-            final int offsetSecond = offset % 60;
-            offset = offset / 60;
+            final int offsetSecond = Math.floorMod(offset, 60);
+            offset = Math.floorDiv(offset, 60);
             if (offsetSecond != 0) {
                 secondOfMinute += offsetSecond;
-                offset += secondOfMinute / 60;
-                secondOfMinute %= 60;
+                offset += Math.floorDiv(secondOfMinute, 60);
+                secondOfMinute = Math.floorMod(secondOfMinute, 60);
             }
 
-            final int offsetMinute = offset % 60;
-            offset = offset / 60;
+            final int offsetMinute = Math.floorMod(offset, 60);
+            offset = Math.floorDiv(offset, 60);
             if (offsetMinute != 0) {
                 minuteOfHour += offsetMinute;
-                offset += minuteOfHour / 60;
-                minuteOfHour %= 60;
+                offset += Math.floorDiv(minuteOfHour, 60);
+                minuteOfHour = Math.floorMod(minuteOfHour, 60);
             }
 
-            final int offsetHour = offset % 24;
-            offset = offset / 24;
+            final int offsetHour = Math.floorMod(offset, 24);
+            offset = Math.floorDiv(offset, 24);
             if (offsetHour != 0) {
                 hourOfDay += offsetHour;
-                offset += hourOfDay / 24;
-                hourOfDay %= 24;
+                offset += Math.floorDiv(hourOfDay, 24);
+                hourOfDay = Math.floorMod(hourOfDay, 24);
             }
 
             if (offset != 0) {
@@ -395,28 +395,28 @@ final class DefaultRubyTimeResolver extends RubyDateTimeResolver {
             }
 
         } else if (0 < offset) {
-            final int offsetSecond = offset % 60;
-            offset /= 60;
+            final int offsetSecond = Math.floorMod(offset, 60);
+            offset = Math.floorDiv(offset, 60);
             if (offsetSecond != 0) {
                 secondOfMinute -= offsetSecond;
-                offset -= secondOfMinute / 60;
-                secondOfMinute %= 60;
+                offset -= Math.floorDiv(secondOfMinute, 60);
+                secondOfMinute = Math.floorMod(secondOfMinute, 60);
             }
 
-            final int offsetMinute = offset % 60;
-            offset /= 60;
+            final int offsetMinute = Math.floorMod(offset, 60);
+            offset = Math.floorDiv(offset, 60);
             if (offsetMinute != 0) {
                 minuteOfHour -= offsetMinute;
-                offset -= minuteOfHour / 60;
-                minuteOfHour %= 60;
+                offset -= Math.floorDiv(minuteOfHour, 60);
+                minuteOfHour = Math.floorMod(minuteOfHour, 60);
             }
 
-            final int offsetHour = offset % 24;
-            offset /= 24;
+            final int offsetHour = Math.floorMod(offset, 24);
+            offset = Math.floorDiv(offset, 24);
             if (offsetHour != 0) {
                 hourOfDay -= offsetHour;
-                offset -= hourOfDay / 24;
-                hourOfDay %= 24;
+                offset -= Math.floorDiv(hourOfDay, 24);
+                hourOfDay = Math.floorMod(hourOfDay, 24);
             }
 
             if (offset != 0) {

--- a/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
+++ b/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
@@ -462,6 +462,53 @@ public class TestRubyDateTimeFormatterParse {
         assertEquals(OffsetDateTime.of(2017, 7, 14, 02, 40, 00, 567111111, ZoneOffset.UTC), datetime);
     }
 
+    @Test
+    public void testOffsets() {
+        assertParsedTime("2019-05-03T00:00:00-00:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Just "-5" should not work.
+        assertParsedTime("2019-05-03T00:00:00-5", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        assertParsedTime("2019-05-03T00:15:24-01:23:45", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 1, 39, 9, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T23:00:00-01:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 4, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T01:00:00-07:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 8, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T23:00:00-07:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 4, 6, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T01:14:19+07:49:12", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 2, 17, 25, 7, 0, ZoneOffset.UTC).toInstant());
+
+        // Go forward through the leap year day (Feb 28 or Feb 29).
+        assertParsedTime("2000-02-28T23:00:00-05", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2000, 2, 29, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2001-02-28T23:00:00-05:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2001, 3, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2004-02-28T23:00:00-05:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2004, 2, 29, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2100-02-28T23:00:00-05:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2100, 3, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Go back through the leap year day (Feb 28 or Feb 29).
+        assertParsedTime("2000-03-01T05:00:00+09", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2000, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2001-03-01T05:00:00+09:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2001, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2004-03-01T05:00:00+09:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2004, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2100-03-01T05:00:00+09:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2100, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Carry up to the year.
+        assertParsedTime("2019-01-01T05:00:00+09:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2018, 12, 31, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-12-31T21:00:00-07:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2020, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+    }
+
     private static TemporalAccessor strptime(final String string, final String format) {
         final RubyDateTimeFormatter formatter = RubyDateTimeFormatter.ofPattern(format);
         return formatter.parseUnresolved(string);


### PR DESCRIPTION
It has been another division bug than #39. It used `/` and `%` operators when applying a time offset (e.g. +09:00), but the dividend could be negative. As a result, it failed to parse a timestamp like `"2019-05-03 03:00:00 +09:00"`.

The time offset `"+09:00"` should make the example to `"2019-05-02 18:00:00Z"` with carrying up to its day. But because of the bug above, it went to `"2019-05-03 (-06):00:00Z"`, and it failed.

The original Ruby code uses `Numeric#divmod` for this calculation.
https://github.com/ruby/ruby/blob/v2_6_3/lib/time.rb#L174
https://docs.ruby-lang.org/en/2.6.0/Numeric.html#method-i-divmod

In Java, it should have been `Math.floorDiv` and `Math.floorMod`, instead of the `/` and `%` operators.