### PR TITLE
Add RubyTemporalQueries.originalText() to return the original text parsed

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/Parsed.java
+++ b/src/main/java/org/embulk/util/rubytime/Parsed.java
@@ -43,7 +43,7 @@ import java.util.Map;
  *
  * @see <a href="http://ruby-doc.org/stdlib-2.5.0/libdoc/date/rdoc/Date.html#method-c-_strptime">Date._strptime</a>
  */
-final class Parsed implements TemporalAccessor {
+final class Parsed implements TemporalAccessor, RubyTemporalQueryResolver {
     private Parsed(
             final String originalString,
 
@@ -762,6 +762,8 @@ final class Parsed implements TemporalAccessor {
             return (R) this.timeZoneName;
         } else if (query == RubyTemporalQueries.leftover()) {
             return (R) this.leftover;
+        } else if (query == RubyTemporalQueries.originalText()) {
+            return query.queryFrom(this);
         } else {
             return TemporalAccessor.super.query(query);
         }
@@ -773,6 +775,11 @@ final class Parsed implements TemporalAccessor {
             return field.range();
         }
         return TemporalAccessor.super.range(field);
+    }
+
+    @Override
+    public String getOriginalText() {
+        return this.originalString;
     }
 
     private final String originalString;

--- a/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
@@ -29,6 +29,15 @@ public final class RubyTemporalQueries {
     }
 
     /**
+     * A query for the original text parsed.
+     *
+     * @return a query that can obtain the original text parsed
+     */
+    public static TemporalQuery<String> originalText() {
+        return RubyTemporalQueries.ORIGINAL_TEXT;
+    }
+
+    /**
      * A query for the time zone name in the same manner with {@code Date._strptime}.
      *
      * @return a query that can obtain the time zone name in the same manner with {@code Date._strptime}
@@ -46,8 +55,20 @@ public final class RubyTemporalQueries {
         return RubyTemporalQueries.LEFTOVER;
     }
 
+    static final TemporalQuery<String> ORIGINAL_TEXT = new OriginalTextQuery();
     static final TemporalQuery<String> RUBY_TIME_ZONE =
             (temporal) -> temporal.query(RubyTemporalQueries.RUBY_TIME_ZONE);
     static final TemporalQuery<String> LEFTOVER =
             (temporal) -> temporal.query(RubyTemporalQueries.LEFTOVER);
+
+    private static class OriginalTextQuery implements TemporalQuery<String> {
+        @Override
+        public final String queryFrom(final TemporalAccessor temporal) {
+            if (temporal instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) temporal;
+                return resolver.getOriginalText();
+            }
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/embulk/util/rubytime/RubyTemporalQueryResolver.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTemporalQueryResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.rubytime;
+
+/**
+ * Interface to resolve Ruby-specific implementations of {@link java.time.temporal.TemporalQuery}.
+ */
+public interface RubyTemporalQueryResolver {
+    String getOriginalText();
+}

--- a/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
+++ b/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
@@ -473,6 +473,7 @@ public class TestRubyDateTimeFormatterParse {
 
         final Instant actualInstant = Instant.from(parsedResolved);
         assertEquals(expected, actualInstant);
+        assertEquals(string, parsedResolved.query(RubyTemporalQueries.originalText()));
     }
 
     private static void assertFailToParse(final String string, final String format) {


### PR DESCRIPTION
The original text (before parsing) is sometimes needed to generate a good `Exception` message. This pull request adds a query for the original text.

@sakama Can you have a look?