### PR TITLE
Cleanup existing RubyTemporalQueries

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/DefaultRubyTimeResolver.java
+++ b/src/main/java/org/embulk/util/rubytime/DefaultRubyTimeResolver.java
@@ -148,6 +148,24 @@ final class DefaultRubyTimeResolver extends RubyDateTimeResolver {
             return null;
         }
 
+        @Override
+        public String getZone() {
+            if (this.original instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) this.original;
+                return resolver.getZone();
+            }
+            return null;
+        }
+
+        @Override
+        public String getLeftover() {
+            if (this.original instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) this.original;
+                return resolver.getLeftover();
+            }
+            return null;
+        }
+
         private final TemporalAccessor original;
         private final OffsetDateTime resolvedDateTime;
     }
@@ -189,7 +207,7 @@ final class DefaultRubyTimeResolver extends RubyDateTimeResolver {
 
         @Override
         public <R> R query(final TemporalQuery<R> query) {
-            if (query == RubyTemporalQueries.originalText()) {
+            if (RubyTemporalQueries.isSpecificQuery(query)) {
                 // Some special queries are prioritized.
                 final R resultOriginal = this.original.query(query);
                 if (resultOriginal != null) {
@@ -233,6 +251,24 @@ final class DefaultRubyTimeResolver extends RubyDateTimeResolver {
             return null;
         }
 
+        @Override
+        public String getZone() {
+            if (this.original instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) this.original;
+                return resolver.getZone();
+            }
+            return null;
+        }
+
+        @Override
+        public String getLeftover() {
+            if (this.original instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) this.original;
+                return resolver.getLeftover();
+            }
+            return null;
+        }
+
         private final TemporalAccessor original;
         private final Instant resolvedInstant;
         private final OffsetDateTime resolvedDateTime;
@@ -246,7 +282,7 @@ final class DefaultRubyTimeResolver extends RubyDateTimeResolver {
      */
     @Override
     public TemporalAccessor resolve(final TemporalAccessor original) {
-        final String zone = original.query(RubyTemporalQueries.rubyTimeZone());
+        final String zone = original.query(RubyTemporalQueries.zone());
         final ZoneOffset offset = RubyTimeZones.toZoneOffset(zone, defaultOffset);
 
         if (offset == null) {

--- a/src/main/java/org/embulk/util/rubytime/Parsed.java
+++ b/src/main/java/org/embulk/util/rubytime/Parsed.java
@@ -758,11 +758,7 @@ final class Parsed implements TemporalAccessor, RubyTemporalQueryResolver {
             return (R) this.parsedExcessDays;
         } else if (query == DateTimeFormatter.parsedLeapSecond()) {
             return (R) ((Boolean) this.parsedLeapSecond);
-        } else if (query == RubyTemporalQueries.rubyTimeZone()) {
-            return (R) this.timeZoneName;
-        } else if (query == RubyTemporalQueries.leftover()) {
-            return (R) this.leftover;
-        } else if (query == RubyTemporalQueries.originalText()) {
+        } else if (RubyTemporalQueries.isSpecificQuery(query)) {
             return query.queryFrom(this);
         } else {
             return TemporalAccessor.super.query(query);
@@ -780,6 +776,16 @@ final class Parsed implements TemporalAccessor, RubyTemporalQueryResolver {
     @Override
     public String getOriginalText() {
         return this.originalString;
+    }
+
+    @Override
+    public String getZone() {
+        return this.timeZoneName;
+    }
+
+    @Override
+    public String getLeftover() {
+        return this.leftover;
     }
 
     private final String originalString;

--- a/src/main/java/org/embulk/util/rubytime/Parsed.java
+++ b/src/main/java/org/embulk/util/rubytime/Parsed.java
@@ -43,7 +43,7 @@ import java.util.Map;
  *
  * @see <a href="http://ruby-doc.org/stdlib-2.5.0/libdoc/date/rdoc/Date.html#method-c-_strptime">Date._strptime</a>
  */
-final class Parsed implements TemporalAccessor {
+final class Parsed implements TemporalAccessor, RubyTemporalQueryResolver {
     private Parsed(
             final String originalString,
 
@@ -762,6 +762,8 @@ final class Parsed implements TemporalAccessor {
             return (R) this.timeZoneName;
         } else if (query == RubyTemporalQueries.leftover()) {
             return (R) this.leftover;
+        } else if (query == RubyTemporalQueries.originalText()) {
+            return query.queryFrom(this);
         } else {
             return TemporalAccessor.super.query(query);
         }
@@ -773,6 +775,11 @@ final class Parsed implements TemporalAccessor {
             return field.range();
         }
         return TemporalAccessor.super.range(field);
+    }
+
+    @Override
+    public String getOriginalText() {
+        return this.originalString;
     }
 
     private final String originalString;

--- a/src/main/java/org/embulk/util/rubytime/RubyDateTimeParsedElementsQuery.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyDateTimeParsedElementsQuery.java
@@ -292,7 +292,7 @@ public final class RubyDateTimeParsedElementsQuery<T> implements TemporalQuery<M
         }
 
         private void putTimeZone() {
-            final String zone = temporal.query(RubyTemporalQueries.rubyTimeZone());
+            final String zone = temporal.query(RubyTemporalQueries.zone());
             if (zone != null) {
                 final int offset = RubyDateTimeZones.toOffsetInSeconds(zone);
                 if (offset != Integer.MIN_VALUE) {

--- a/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
@@ -29,6 +29,15 @@ public final class RubyTemporalQueries {
     }
 
     /**
+     * A query for the original text parsed.
+     *
+     * @return a query that can obtain the original text parsed
+     */
+    public static TemporalQuery<String> originalText() {
+        return RubyTemporalQueries.ORIGINAL_TEXT;
+    }
+
+    /**
      * A query for the time zone name in the same manner with {@code Date._strptime}.
      *
      * @return a query that can obtain the time zone name in the same manner with {@code Date._strptime}
@@ -46,8 +55,20 @@ public final class RubyTemporalQueries {
         return RubyTemporalQueries.LEFTOVER;
     }
 
+    static final TemporalQuery<String> ORIGINAL_TEXT = new OriginalTextQuery();
     static final TemporalQuery<String> RUBY_TIME_ZONE =
             (temporal) -> temporal.query(RubyTemporalQueries.RUBY_TIME_ZONE);
     static final TemporalQuery<String> LEFTOVER =
             (temporal) -> temporal.query(RubyTemporalQueries.LEFTOVER);
+
+    private static class OriginalTextQuery implements TemporalQuery<String> {
+        @Override
+        public final String queryFrom(final TemporalAccessor temporal) {
+            if (temporal instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) temporal;
+                return resolver.getOriginalText();
+            }
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTemporalQueries.java
@@ -28,6 +28,10 @@ public final class RubyTemporalQueries {
         // No instantiation.
     }
 
+    public static boolean isSpecificQuery(final TemporalQuery<?> query) {
+        return (query == ORIGINAL_TEXT || query == ZONE || query == LEFTOVER);
+    }
+
     /**
      * A query for the original text parsed.
      *
@@ -42,8 +46,8 @@ public final class RubyTemporalQueries {
      *
      * @return a query that can obtain the time zone name in the same manner with {@code Date._strptime}
      */
-    public static TemporalQuery<String> rubyTimeZone() {
-        return RubyTemporalQueries.RUBY_TIME_ZONE;
+    public static TemporalQuery<String> zone() {
+        return RubyTemporalQueries.ZONE;
     }
 
     /**
@@ -56,10 +60,8 @@ public final class RubyTemporalQueries {
     }
 
     static final TemporalQuery<String> ORIGINAL_TEXT = new OriginalTextQuery();
-    static final TemporalQuery<String> RUBY_TIME_ZONE =
-            (temporal) -> temporal.query(RubyTemporalQueries.RUBY_TIME_ZONE);
-    static final TemporalQuery<String> LEFTOVER =
-            (temporal) -> temporal.query(RubyTemporalQueries.LEFTOVER);
+    static final TemporalQuery<String> ZONE = new ZoneQuery();
+    static final TemporalQuery<String> LEFTOVER = new LeftoverQuery();
 
     private static class OriginalTextQuery implements TemporalQuery<String> {
         @Override
@@ -67,6 +69,28 @@ public final class RubyTemporalQueries {
             if (temporal instanceof RubyTemporalQueryResolver) {
                 final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) temporal;
                 return resolver.getOriginalText();
+            }
+            return null;
+        }
+    }
+
+    private static class ZoneQuery implements TemporalQuery<String> {
+        @Override
+        public final String queryFrom(final TemporalAccessor temporal) {
+            if (temporal instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) temporal;
+                return resolver.getZone();
+            }
+            return null;
+        }
+    }
+
+    private static class LeftoverQuery implements TemporalQuery<String> {
+        @Override
+        public final String queryFrom(final TemporalAccessor temporal) {
+            if (temporal instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) temporal;
+                return resolver.getLeftover();
             }
             return null;
         }

--- a/src/main/java/org/embulk/util/rubytime/RubyTemporalQueryResolver.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTemporalQueryResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.rubytime;
+
+/**
+ * Interface to resolve Ruby-specific implementations of {@link java.time.temporal.TemporalQuery}.
+ */
+public interface RubyTemporalQueryResolver {
+    String getOriginalText();
+}

--- a/src/main/java/org/embulk/util/rubytime/RubyTemporalQueryResolver.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyTemporalQueryResolver.java
@@ -21,4 +21,6 @@ package org.embulk.util.rubytime;
  */
 public interface RubyTemporalQueryResolver {
     String getOriginalText();
+    String getZone();
+    String getLeftover();
 }

--- a/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
+++ b/src/test/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterParse.java
@@ -473,6 +473,7 @@ public class TestRubyDateTimeFormatterParse {
 
         final Instant actualInstant = Instant.from(parsedResolved);
         assertEquals(expected, actualInstant);
+        assertEquals(string, parsedResolved.query(RubyTemporalQueries.originalText()));
     }
 
     private static void assertFailToParse(final String string, final String format) {

--- a/src/test/resources/time_monkey_patch.rb
+++ b/src/test/resources/time_monkey_patch.rb
@@ -32,7 +32,7 @@ module TimeMonkeyPatch
         nano = parsedResolved.get(Java::java.time.temporal.ChronoField::NANO_OF_SECOND)
 
         # TODO: Get the zone offset directly from the resolved object, not from the parsed object.
-        # Querying rubyTimeZone for the resolved object may fail as of now.
+        # Querying RubyTemporalQueries.zone() for the resolved object may fail as of now.
         begin
           parsed = formatter.parseUnresolved(date)
         rescue Java::org.embulk.util.rubytime.RubyDateTimeParseException
@@ -41,7 +41,7 @@ module TimeMonkeyPatch
         if parsed.nil?
           raise 'RubyDateTimeFormatter#parseUnresolved returned null unexpectedly.'
         end
-        zone_string = parsed.query(Java::org.embulk.util.rubytime.RubyTemporalQueries.rubyTimeZone())
+        zone_string = parsed.query(Java::org.embulk.util.rubytime.RubyTemporalQueries.zone())
 
         offset = Java::org.embulk.util.rubytime.RubyTimeZones.toZoneOffset(
           zone_string, Java::java.time.ZoneOffset::UTC).getTotalSeconds()


### PR DESCRIPTION
Using instance equality and recursive calls in processing Ruby-specific `TemporalQuery` could cause infinite method calls. This commit stops using them.

Also it renames `RubyTemporalQueries.rubyTimeZone` to `RubyTemporalQueries.zone`.