### PR TITLE
Test with multi-versions of CRuby with GitHub Actions Matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,22 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Set up Ruby 2.6
+    - name: Build with testing
+      run: ./gradlew --stacktrace test jruby9_1_15Test jruby9_1_17Test jruby9_2_0Test jruby9_2_9Test build
+  crubyTest:
+    strategy:
+      matrix:
+        ruby: [2.4.x, 2.5.x, 2.6.x]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - name: Build with testing
-      run: ./gradlew --stacktrace test crubyTest jruby9_1_15Test jruby9_1_17Test jruby9_2_0Test jruby9_2_9Test build
+      run: ./gradlew crubyTest


### PR DESCRIPTION
It runs `crubyTest` with multiple versions of CRuby: 2.4, 2.5, and 2.6.