### PR TITLE
Support directive options for formatters in Format

### DIFF
--- a/src/main/java/org/embulk/util/rubytime/Format.java
+++ b/src/main/java/org/embulk/util/rubytime/Format.java
@@ -28,14 +28,26 @@ import java.util.Objects;
 final class Format implements Iterable<Format.TokenWithNext> {
     private Format(final List<FormatToken> compiledPattern) {
         this.compiledPattern = Collections.unmodifiableList(compiledPattern);
+
+        boolean onlyForFormatter = false;
+        for (final FormatToken token : compiledPattern) {
+            if (token.onlyForFormatter()) {
+                onlyForFormatter = true;
+            }
+        }
+        this.onlyForFormatter = onlyForFormatter;
     }
 
     public static Format compile(final String formatString) {
-        return new Format(CompilerForParser.compile(formatString));
+        return new Format(Compiler.compile(formatString));
     }
 
     static Format createForTesting(final List<FormatToken> compiledPattern) {
         return new Format(compiledPattern);
+    }
+
+    boolean onlyForFormatter() {
+        return this.onlyForFormatter;
     }
 
     @Override
@@ -50,6 +62,11 @@ final class Format implements Iterable<Format.TokenWithNext> {
     @Override
     public int hashCode() {
         return Objects.hash(this.compiledPattern);
+    }
+
+    @Override
+    public String toString() {
+        return this.compiledPattern.toString();
     }
 
     @Override
@@ -75,13 +92,19 @@ final class Format implements Iterable<Format.TokenWithNext> {
         private final FormatToken nextToken;
     }
 
-    private static class CompilerForParser {
-        private CompilerForParser(final String formatString) {
+    /**
+     * Compiles a date-time format string into internal representation, which is available both for parsing and formatting.
+     *
+     * @see <a href="https://github.com/ruby/ruby/blob/v2_6_5/ext/date/date_strptime.c#L164-L651">date__strptime_internal</a>
+     * @see <a href="https://github.com/ruby/ruby/blob/v2_6_5/strftime.c#L222-L907">rb_strftime_with_timespec</a>
+     */
+    private static class Compiler {
+        private Compiler(final String formatString) {
             this.formatString = formatString;
         }
 
         public static List<FormatToken> compile(final String formatString) {
-            return new CompilerForParser(formatString).compileInitial();
+            return new Compiler(formatString).compileInitial();
         }
 
         private List<FormatToken> compileInitial() {
@@ -114,52 +137,211 @@ final class Format implements Iterable<Format.TokenWithNext> {
             return Collections.unmodifiableList(this.resultTokens);
         }
 
+        /**
+         * Compiles {@code formatString} from {@code [beginningIndex]} as a directive.
+         *
+         * <p>The compiled directives are pushed into {@code resultTokens} if recognized as a directive.
+         *
+         * @param beginningIndex  index of the character next to {@code '%'} in {@code formatString}.
+         * @return {@code true} if recognized as a directive, {@code false} otherwise.
+         */
         private boolean compileDirective(final int beginningIndex) {
-            if (beginningIndex >= this.formatString.length()) {
-                return false;
-            }
-            final char cur = this.formatString.charAt(beginningIndex);
-            switch (cur) {
-                case 'E':
-                    if (beginningIndex + 1 < this.formatString.length()
-                            && "cCxXyY".indexOf(this.formatString.charAt(beginningIndex + 1)) >= 0) {
-                        return this.compileDirective(beginningIndex + 1);
-                    } else {
-                        return false;
-                    }
-                case 'O':
-                    if (beginningIndex + 1 < this.formatString.length()
-                            && "deHImMSuUVwWy".indexOf(this.formatString.charAt(beginningIndex + 1)) >= 0) {
-                        return this.compileDirective(beginningIndex + 1);
-                    } else {
-                        return false;
-                    }
-                case ':':
-                    for (int i = 1; i <= 3; ++i) {
-                        if (beginningIndex + i >= this.formatString.length()) {
-                            return false;
-                        }
-                        if (this.formatString.charAt(beginningIndex + i) == 'z') {
-                            return this.compileDirective(beginningIndex + i);
-                        }
-                        if (this.formatString.charAt(beginningIndex + i) != ':') {
-                            return false;
-                        }
-                    }
-                    return false;
-                case '%':
-                    this.resultTokens.add(FormatToken.immediate("%"));
-                    this.index = beginningIndex + 1;
-                    return true;
-                default:
-                    if (FormatDirective.isSpecifier(cur)) {
-                        this.resultTokens.addAll(FormatDirective.of(cur).toTokens());
-                        this.index = beginningIndex + 1;
+            final FormatDirectiveOptions.Builder optionsBuilder = FormatDirectiveOptions.builder();
+
+            for (int cursorIndex = beginningIndex; cursorIndex < this.formatString.length(); cursorIndex++) {
+                final char cur = this.formatString.charAt(cursorIndex);
+                switch (cur) {
+                    case '%':  // FormatDirective.IMMEDIATE_PERCENT:
+                    case 'n':  // FormatDirective.IMMEDIATE_NEWLINE
+                    case 't':  // FormatDirective.IMMEDIATE_TAB
+                        // They are compiled as directives so that options can work for formatting. For example,
+                        //
+                        //    irb(main):001:0> Time.now.strftime("%10%")
+                        //    => "         %"
+                        //    irb(main):002:0> Time.now.strftime("%010n")
+                        //    => "000000000\n"
+
+                    case 'a':  // FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME
+                    case 'A':  // FormatDirective.DAY_OF_WEEK_FULL_NAME
+                    case 'h':  // FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME_ALIAS_SMALL_H
+                    case 'b':  // FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME
+                    case 'B':  // FormatDirective.MONTH_OF_YEAR_FULL_NAME
+
+                    case 'P':  // FormatDirective.AMPM_OF_DAY_LOWER_CASE
+                    case 'p':  // FormatDirective.AMPM_OF_DAY_UPPER_CASE
+
+                    case 'c':  // FormatDirective.RECURRED_UPPER_C
+                    case 'x':  // FormatDirective.RECURRED_LOWER_X
+                    case 'X':  // FormatDirective.RECURRED_UPPER_X
+                    case 'D':  // FormatDirective.RECURRED_UPPER_D
+                    case 'r':  // FormatDirective.RECURRED_LOWER_R
+                    case 'R':  // FormatDirective.RECURRED_UPPER_R
+                    case 'T':  // FormatDirective.RECURRED_UPPER_T
+                    case 'v':  // FormatDirective.RECURRED_LOWER_V
+                    case 'F':  // FormatDirective.RECURRED_UPPER_F
+                    case '+':  // FormatDirective.RECURRED_PLUS
+
+                    case 'd':  // FormatDirective.DAY_OF_MONTH_ZERO_PADDED
+                    case 'H':  // FormatDirective.HOUR_OF_DAY_ZERO_PADDED
+                    case 'I':  // FormatDirective.HOUR_OF_AMPM_ZERO_PADDED
+                    case 'j':  // FormatDirective.DAY_OF_YEAR
+                    case 'm':  // FormatDirective.MONTH_OF_YEAR
+                    case 'M':  // FormatDirective.MINUTE_OF_HOUR
+                    case 's':  // FormatDirective.SECONDS_SINCE_EPOCH
+                    case 'S':  // FormatDirective.SECOND_OF_MINUTE
+                    case 'U':  // FormatDirective.WEEK_OF_YEAR_STARTING_WITH_SUNDAY
+                    case 'W':  // FormatDirective.WEEK_OF_YEAR_STARTING_WITH_MONDAY
+                    case 'w':  // FormatDirective.DAY_OF_WEEK_STARTING_WITH_SUNDAY_0
+                    case 'y':  // FormatDirective.YEAR_WITHOUT_CENTURY
+                    case 'Y':  // FormatDirective.YEAR_WITH_CENTURY
+                    case 'e':  // FormatDirective.DAY_OF_MONTH_BLANK_PADDED
+                    case 'k':  // FormatDirective.HOUR_OF_DAY_BLANK_PADDED
+                    case 'l':  // FormatDirective.HOUR_OF_AMPM_BLANK_PADDED
+                    case 'C':  // FormatDirective.CENTURY -- FMTV
+                    case 'V':  // FormatDirective.WEEK_OF_WEEK_BASED_YEAR
+                    case 'u':  // FormatDirective.DAY_OF_WEEK_STARTING_WITH_MONDAY_1
+
+                    case 'Q':  // FormatDirective.MILLISECONDS_SINCE_EPOCH
+                        // %Q is only for parsing, not for formatting. Then, %Q never takes any option.
+                        // So, a token of "%Q" can always be stringified straightforward to "%Q".
+
+                    case 'z':  // FormatDirective.TIME_OFFSET
+
+                    case 'Z':  // FormatDirective.TIME_ZONE_NAME
+
+                    case 'G':  // FormatDirective.WEEK_BASED_YEAR_WITH_CENTURY
+                    case 'g':  // FormatDirective.WEEK_BASED_YEAR_WITHOUT_CENTURY
+
+                    case 'L':  // FormatDirective.MILLI_OF_SECOND
+                    case 'N':  // FormatDirective.NANO_OF_SECOND
+                        this.resultTokens.add(FormatToken.directive(
+                                "%" + this.formatString.substring(beginningIndex, cursorIndex + 1),
+                                FormatDirective.of(cur),
+                                optionsBuilder.build()));
+                        this.index = cursorIndex + 1;
                         return true;
-                    } else {
+
+                    case 'E':
+                        if (cursorIndex + 1 < this.formatString.length()
+                                && "cCxXyY".indexOf(this.formatString.charAt(cursorIndex + 1)) >= 0) {
+                            break;
+                        } else {
+                            return false;
+                        }
+                    case 'O':
+                        if (cursorIndex + 1 < this.formatString.length()
+                                && "deHImMSuUVwWy".indexOf(this.formatString.charAt(cursorIndex + 1)) >= 0) {
+                            break;
+                        } else {
+                            return false;
+                        }
+
+                    case '-':
+                        if (optionsBuilder.isPrecisionSpecified()) {
+                            return false;
+                        }
+                        optionsBuilder.setLeft();
+                        break;
+
+                    case '^':
+                        if (optionsBuilder.isPrecisionSpecified()) {
+                            return false;
+                        }
+                        optionsBuilder.setUpper();
+                        break;
+
+                    case '#':
+                        if (optionsBuilder.isPrecisionSpecified()) {
+                            return false;
+                        }
+                        optionsBuilder.setChCase();
+                        break;
+
+                    case '_':
+                        if (optionsBuilder.isPrecisionSpecified()) {
+                            return false;
+                        }
+                        optionsBuilder.setPadding(' ');
+                        break;
+
+                    case ':':
+                        // strptime accepts only 3 colons at maximum.
+                        // strftime accepts unlimited number of colons.
+                        for (int i = 1; ; i++) {
+                            if (cursorIndex + i >= this.formatString.length()) {
+                                return false;
+                            }
+                            if (this.formatString.charAt(cursorIndex + i) == 'z') {
+                                optionsBuilder.setColons(i);
+                                cursorIndex += (i - 1);
+                                break;
+                            }
+                            if (this.formatString.charAt(cursorIndex + i) != ':') {
+                                return false;
+                            }
+                        }
+                        break;
+
+                    case '0':
+                        optionsBuilder.setPadding('0');
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                        {
+                            final String digits = this.consumeDigits(cursorIndex);
+                            if (digits == null) {
+                                return false;
+                            }
+                            optionsBuilder.setPrecision(Integer.parseInt(digits));
+                            cursorIndex += digits.length() - 1;
+                        }
+                        break;
+
+                    default:
                         return false;
-                    }
+                }
             }
+            return false;
+        }
+
+        /**
+         * Consumes digits in a format directive token.
+         *
+         * <pre>{@code
+         * Time.now.strftime("%-2147483647s")
+         * => "1576139531"
+         * Time.now.strftime("%-2147483648s")
+         * => "%-2147483648s"
+         * }</pre>
+         */
+        private String consumeDigits(final int start) {
+            int startNonZero = start;
+            for (; startNonZero < this.formatString.length() && this.formatString.charAt(startNonZero) == '0'; startNonZero++) {
+            }
+
+            int endDigit = startNonZero;
+            for (; endDigit < this.formatString.length() && isDigit(this.formatString.charAt(endDigit)); endDigit++) {
+            }
+
+            if (endDigit - startNonZero > 10) {
+                return null;
+            }
+
+            final String digits = this.formatString.substring(startNonZero, endDigit);
+            if (endDigit > startNonZero) {
+                final long parsedLong = Long.parseLong(digits);
+                if (parsedLong > Integer.MAX_VALUE) {
+                    return null;
+                }
+            }
+
+            return this.formatString.substring(start, endDigit);
         }
 
         private final String formatString;
@@ -200,5 +382,15 @@ final class Format implements Iterable<Format.TokenWithNext> {
         private FormatToken next;
     }
 
+    /**
+     * Determines if the specified character is a digit.
+     *
+     * <p>It accepts only ASCII digit characters intentionally.
+     */
+    private static boolean isDigit(final char c) {
+        return '0' <= c && c <= '9';
+    }
+
     private final List<FormatToken> compiledPattern;
+    private final boolean onlyForFormatter;
 }

--- a/src/main/java/org/embulk/util/rubytime/Format.java
+++ b/src/main/java/org/embulk/util/rubytime/Format.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Represents a Ruby-compatible date-time format.
@@ -44,6 +45,11 @@ final class Format implements Iterable<Format.TokenWithNext> {
         }
         final Format other = (Format) otherObject;
         return this.compiledPattern.equals(other.compiledPattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.compiledPattern);
     }
 
     @Override
@@ -88,7 +94,7 @@ final class Format implements Iterable<Format.TokenWithNext> {
                 switch (cur) {
                     case '%':
                         if (this.rawStringBuffer.length() > 0) {
-                            this.resultTokens.add(new FormatToken.Immediate(this.rawStringBuffer.toString()));
+                            this.resultTokens.add(FormatToken.immediate(this.rawStringBuffer.toString()));
                         }
                         this.rawStringBuffer = new StringBuilder();
                         this.index++;
@@ -102,7 +108,7 @@ final class Format implements Iterable<Format.TokenWithNext> {
                 }
             }
             if (this.rawStringBuffer.length() > 0) {
-                this.resultTokens.add(new FormatToken.Immediate(this.rawStringBuffer.toString()));
+                this.resultTokens.add(FormatToken.immediate(this.rawStringBuffer.toString()));
             }
 
             return Collections.unmodifiableList(this.resultTokens);
@@ -142,7 +148,7 @@ final class Format implements Iterable<Format.TokenWithNext> {
                     }
                     return false;
                 case '%':
-                    this.resultTokens.add(new FormatToken.Immediate("%"));
+                    this.resultTokens.add(FormatToken.immediate("%"));
                     this.index = beginningIndex + 1;
                     return true;
                 default:

--- a/src/main/java/org/embulk/util/rubytime/FormatDirective.java
+++ b/src/main/java/org/embulk/util/rubytime/FormatDirective.java
@@ -164,7 +164,7 @@ enum FormatDirective {
             // Non-recurred directives first so that recurred directives can use tokens of non-recurred directives.
             if (!directive.isRecurred) {
                 final ArrayList<FormatToken> tokensBuilt = new ArrayList<>();
-                tokensBuilt.add(new FormatToken.Directive(directive));
+                tokensBuilt.add(FormatToken.directive(directive));
                 directiveTokensMapBuilt.put(directive, Collections.unmodifiableList(tokensBuilt));
             }
         }
@@ -175,7 +175,7 @@ enum FormatDirective {
                     final FormatDirective eachDirective =
                             charDirectiveMapBuilt.get(directive.recurred.charAt(i));
                     if (eachDirective == null) {
-                        tokensBuilt.add(new FormatToken.Immediate(directive.recurred.charAt(i)));
+                        tokensBuilt.add(FormatToken.immediate(directive.recurred.charAt(i)));
                     } else {
                         tokensBuilt.add(directiveTokensMapBuilt.get(eachDirective).get(0));
                     }

--- a/src/main/java/org/embulk/util/rubytime/FormatDirective.java
+++ b/src/main/java/org/embulk/util/rubytime/FormatDirective.java
@@ -24,39 +24,50 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Enumerates constants to represent Ruby-compatible date-time format directives.
+ * Enumerates directives of Ruby-compatible date-time format.
  *
- * @see <a href="https://docs.ruby-lang.org/en/2.4.0/Time.html#method-i-strftime">Ruby v2.4.0's datetime format</a>
+ * <ul>
+ * <li>Directive: means the special tokens to be used to parse and format. For example, {@code "%Y"} and {@code "%^B"}.
+ * <li>(Conversion) Specifier: means the last character of a directive. For example, {@code 's'} of {@code "%012s"}.
+ * <li>Option: means modifiers of a directive, excluding its specifier. For example, {@code "-12"} of {@code "%-12s"}.
+ * </ul>
+ *
+ * <p>Ruby's parser ({@code strptime}) and formatter ({@code strftime}) share almost the same format directives,
+ * but they have some differences. The parser do not accept options except for {@code ":"} for {@code "%z"}.
+ * The formattter accepts options, but it does not have {@code "%Q"}.
+ *
+ * @see <a href="https://docs.ruby-lang.org/en/2.6.0/Time.html#method-c-strptime">Time::strptime</a>
+ * @see <a href="https://docs.ruby-lang.org/en/2.6.0/Time.html#method-i-strftime">Time#strftime</a>
  */
 enum FormatDirective {
     // Date (Year, Month, Day):
 
-    YEAR_WITH_CENTURY(true, 'Y'),
-    CENTURY(true, 'C'),
-    YEAR_WITHOUT_CENTURY(true, 'y'),
+    YEAR_WITH_CENTURY(true, 'Y'),  // '0', 4, defaultPrecision = 5 if <= 0
+    CENTURY(true, 'C'),  /// '0', 2
+    YEAR_WITHOUT_CENTURY(true, 'y'),  // '0', 2
 
-    MONTH_OF_YEAR(true, 'm'),
+    MONTH_OF_YEAR(true, 'm'),  // '0', 2
     MONTH_OF_YEAR_FULL_NAME(false, 'B'),
     MONTH_OF_YEAR_ABBREVIATED_NAME(false, 'b'),
     MONTH_OF_YEAR_ABBREVIATED_NAME_ALIAS_SMALL_H(false, 'h'),
 
-    DAY_OF_MONTH_ZERO_PADDED(true, 'd'),
-    DAY_OF_MONTH_BLANK_PADDED(true, 'e'),
+    DAY_OF_MONTH_ZERO_PADDED(true, 'd'),  // '0', 2
+    DAY_OF_MONTH_BLANK_PADDED(true, 'e'),  // ' ', 2
 
-    DAY_OF_YEAR(true, 'j'),
+    DAY_OF_YEAR(true, 'j'),  // '0', 3
 
     // Time (Hour, Minute, Second, Subsecond):
 
-    HOUR_OF_DAY_ZERO_PADDED(true, 'H'),
-    HOUR_OF_DAY_BLANK_PADDED(true, 'k'),
-    HOUR_OF_AMPM_ZERO_PADDED(true, 'I'),
-    HOUR_OF_AMPM_BLANK_PADDED(true, 'l'),
+    HOUR_OF_DAY_ZERO_PADDED(true, 'H'),  // '0', 2
+    HOUR_OF_DAY_BLANK_PADDED(true, 'k'),  // ' ', 2
+    HOUR_OF_AMPM_ZERO_PADDED(true, 'I'),  // '0', 2
+    HOUR_OF_AMPM_BLANK_PADDED(true, 'l'),  // ' ', 2
     AMPM_OF_DAY_LOWER_CASE(false, 'P'),
     AMPM_OF_DAY_UPPER_CASE(false, 'p'),
 
-    MINUTE_OF_HOUR(true, 'M'),
+    MINUTE_OF_HOUR(true, 'M'),  // '0', 2
 
-    SECOND_OF_MINUTE(true, 'S'),
+    SECOND_OF_MINUTE(true, 'S'),  // '0', 2
 
     MILLI_OF_SECOND(true, 'L'),
     NANO_OF_SECOND(true, 'N'),
@@ -70,66 +81,58 @@ enum FormatDirective {
 
     DAY_OF_WEEK_FULL_NAME(false, 'A'),
     DAY_OF_WEEK_ABBREVIATED_NAME(false, 'a'),
-    DAY_OF_WEEK_STARTING_WITH_MONDAY_1(true, 'u'),
-    DAY_OF_WEEK_STARTING_WITH_SUNDAY_0(true, 'w'),
+    DAY_OF_WEEK_STARTING_WITH_MONDAY_1(true, 'u'),  // '0', 1
+    DAY_OF_WEEK_STARTING_WITH_SUNDAY_0(true, 'w'),  // '0', 1
 
     // ISO 8601 week-based year and week number:
     // The first week of YYYY starts with a Monday and includes YYYY-01-04.
     // The days in the year before the first week are in the last week of
     // the previous year.
 
-    WEEK_BASED_YEAR_WITH_CENTURY(true, 'G'),
-    WEEK_BASED_YEAR_WITHOUT_CENTURY(true, 'g'),
-    WEEK_OF_WEEK_BASED_YEAR(true, 'V'),
+    WEEK_BASED_YEAR_WITH_CENTURY(true, 'G'),  // '0', 4, defaultPrecision = 5 if <= 0
+    WEEK_BASED_YEAR_WITHOUT_CENTURY(true, 'g'),  // '0', 2
+    WEEK_OF_WEEK_BASED_YEAR(true, 'V'),  // '0', 2
 
     // Week number:
     // The first week of YYYY that starts with a Sunday or Monday (according to %U
     // or %W). The days in the year before the first week are in week 0.
 
-    WEEK_OF_YEAR_STARTING_WITH_SUNDAY(true, 'U'),
-    WEEK_OF_YEAR_STARTING_WITH_MONDAY(true, 'W'),
+    WEEK_OF_YEAR_STARTING_WITH_SUNDAY(true, 'U'),  // '0', 2
+    WEEK_OF_YEAR_STARTING_WITH_MONDAY(true, 'W'),  // '0', 2
 
     // Seconds since the Epoch:
 
-    SECONDS_SINCE_EPOCH(true, 's'),
-    MILLISECONDS_SINCE_EPOCH(false, 'Q'),  // TODO: Revisit this "%Q" is not a numeric pattern?
+    SECONDS_SINCE_EPOCH(true, 's'),  // '0', 1
+    MILLISECONDS_SINCE_EPOCH(false, 'Q'),
+
+    // Immediates:
+
+    IMMEDIATE_PERCENT(false, '%'),
+    IMMEDIATE_NEWLINE(false, 'n'),
+    IMMEDIATE_TAB(false, 't'),
 
     // Recurred:
 
-    RECURRED_UPPER_C('c', "a b e H:M:S Y"),
-    RECURRED_UPPER_D('D', "m/d/y"),
-    RECURRED_LOWER_X('x', "m/d/y"),
-    RECURRED_UPPER_F('F', "Y-m-d"),
-    RECURRED_LOWER_N('n', "\n"),
-    RECURRED_UPPER_R('R', "H:M"),
-    RECURRED_LOWER_R('r', "I:M:S p"),
-    RECURRED_UPPER_T('T', "H:M:S"),
-    RECURRED_UPPER_X('X', "H:M:S"),
-    RECURRED_LOWER_T('t', "\t"),
-    RECURRED_LOWER_V('v', "e-b-Y"),
-    RECURRED_PLUS('+', "a b e H:M:S Z Y"),
+    RECURRED_LOWER_C('c'),
+    RECURRED_UPPER_D('D'),
+    RECURRED_LOWER_X('x'),
+    RECURRED_UPPER_F('F'),
+    RECURRED_UPPER_R('R'),
+    RECURRED_LOWER_R('r'),
+    RECURRED_UPPER_T('T'),
+    RECURRED_UPPER_X('X'),
+    RECURRED_LOWER_V('v'),
+    RECURRED_PLUS('+'),
     ;
 
     private FormatDirective(final boolean isNumeric, final char conversionSpecifier) {
         this.conversionSpecifier = conversionSpecifier;
         this.isNumeric = isNumeric;
-        this.isRecurred = false;
-        this.recurred = null;
     }
 
-    private FormatDirective(final char conversionSpecifier, final String recurred) {
+    private FormatDirective(final char conversionSpecifier) {
         this.conversionSpecifier = conversionSpecifier;
         this.isNumeric = false;
-        this.isRecurred = true;
-        this.recurred = recurred;
-    }
-
-    private FormatDirective() {
-        this(false, '\0');
-    }
-
-    static boolean isSpecifier(final char conversionSpecifier) {
-        return FROM_CONVERSION_SPECIFIER.containsKey(conversionSpecifier);
     }
 
     static FormatDirective of(final char conversionSpecifier) {
@@ -141,12 +144,12 @@ enum FormatDirective {
         return "" + this.conversionSpecifier;
     }
 
-    boolean isNumeric() {
-        return this.isNumeric;
+    char getSpecifier() {
+        return this.conversionSpecifier;
     }
 
-    List<FormatToken> toTokens() {
-        return TO_TOKENS.get(this);
+    boolean isNumeric() {
+        return this.isNumeric;
     }
 
     static {
@@ -157,40 +160,10 @@ enum FormatDirective {
             }
         }
         FROM_CONVERSION_SPECIFIER = Collections.unmodifiableMap(charDirectiveMapBuilt);
-
-        final EnumMap<FormatDirective, List<FormatToken>> directiveTokensMapBuilt =
-                new EnumMap<>(FormatDirective.class);
-        for (final FormatDirective directive : values()) {
-            // Non-recurred directives first so that recurred directives can use tokens of non-recurred directives.
-            if (!directive.isRecurred) {
-                final ArrayList<FormatToken> tokensBuilt = new ArrayList<>();
-                tokensBuilt.add(FormatToken.directive(directive));
-                directiveTokensMapBuilt.put(directive, Collections.unmodifiableList(tokensBuilt));
-            }
-        }
-        for (final FormatDirective directive : values()) {
-            if (directive.isRecurred) {
-                final ArrayList<FormatToken> tokensBuilt = new ArrayList<>();
-                for (int i = 0; i < directive.recurred.length(); ++i) {
-                    final FormatDirective eachDirective =
-                            charDirectiveMapBuilt.get(directive.recurred.charAt(i));
-                    if (eachDirective == null) {
-                        tokensBuilt.add(FormatToken.immediate(directive.recurred.charAt(i)));
-                    } else {
-                        tokensBuilt.add(directiveTokensMapBuilt.get(eachDirective).get(0));
-                    }
-                }
-                directiveTokensMapBuilt.put(directive, Collections.unmodifiableList(tokensBuilt));
-            }
-        }
-        TO_TOKENS = Collections.unmodifiableMap(directiveTokensMapBuilt);
     }
 
     private static final Map<Character, FormatDirective> FROM_CONVERSION_SPECIFIER;
-    private static final Map<FormatDirective, List<FormatToken>> TO_TOKENS;
 
     private final char conversionSpecifier;
     private final boolean isNumeric;
-    private final boolean isRecurred;
-    private final String recurred;
 }

--- a/src/main/java/org/embulk/util/rubytime/FormatDirectiveOptions.java
+++ b/src/main/java/org/embulk/util/rubytime/FormatDirectiveOptions.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.rubytime;
+
+import java.util.Objects;
+
+/**
+ * Represents a token instance in Ruby-compatible date-time format strings.
+ *
+ * <p>It represents explicitly-specified options. Default values are not considered in this class.
+ */
+final class FormatDirectiveOptions {
+    private FormatDirectiveOptions(
+            final boolean onlyForFormatter,
+            final int precision,
+            final boolean isLeft,
+            final boolean isUpper,
+            final boolean isChCase,
+            final char padding,
+            final int colons) {
+        this.onlyForFormatter = onlyForFormatter;
+        this.precision = precision;
+        this.isLeft = isLeft;
+        this.isUpper = isUpper;
+        this.isChCase = isChCase;
+        this.padding = padding;
+        this.colons = colons;
+    }
+
+    static class Builder {
+        Builder() {
+            this.onlyForFormatter = false;
+            this.precision = 0;
+            this.isLeft = false;
+            this.isUpper = false;
+            this.isChCase = false;
+            this.padding = '\0';
+            this.colons = 0;
+        }
+
+        Builder setColons(final int colons) {
+            if (colons <= 0) {
+                throw new IllegalArgumentException();
+            }
+            if (this.colons > 0) {  // Colons must be consequent -- no double sets.
+                throw new IllegalArgumentException();
+            }
+            if (colons > 3) {
+                this.onlyForFormatter = true;
+            }
+            this.colons = colons;
+            return this;
+        }
+
+        Builder setPadding(final char padding) {
+            this.onlyForFormatter = true;
+            this.padding = padding;
+            return this;
+        }
+
+        Builder setLeft() {
+            this.onlyForFormatter = true;
+            this.isLeft = true;
+            return this;
+        }
+
+        Builder setUpper() {
+            this.onlyForFormatter = true;
+            this.isUpper = true;
+            return this;
+        }
+
+        Builder setChCase() {
+            this.onlyForFormatter = true;
+            this.isChCase = true;
+            return this;
+        }
+
+        Builder setPrecision(final int precision) {
+            this.onlyForFormatter = true;
+            this.precision = precision;
+            return this;
+        }
+
+        boolean isPrecisionSpecified() {
+            return this.precision > 0;
+        }
+
+        FormatDirectiveOptions build() {
+            return new FormatDirectiveOptions(
+                    this.onlyForFormatter,
+                    this.precision,
+                    this.isLeft,
+                    this.isUpper,
+                    this.isChCase,
+                    this.padding,
+                    this.colons);
+        }
+
+        private boolean onlyForFormatter;
+
+        private int precision;
+        private boolean isLeft;
+        private boolean isUpper;
+        private boolean isChCase;
+        private char padding;
+        private int colons;
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    boolean onlyForFormatter() {
+        return this.onlyForFormatter;
+    }
+
+    int getPrecision(final int defaultPrecision) {
+        if (this.precision <= 0) {
+            return defaultPrecision;
+        }
+        return this.precision;
+    }
+
+    boolean isLeft() {
+        return this.isLeft;
+    }
+
+    boolean isUpper() {
+        return this.isUpper;
+    }
+
+    boolean isChCase() {
+        return this.isChCase;
+    }
+
+    char getPadding(final char defaultPadding) {
+        if (this.padding == '\0') {
+            return defaultPadding;
+        }
+        return this.padding;
+    }
+
+    int getColons() {
+        return this.colons;
+    }
+
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (!(otherObject instanceof FormatDirectiveOptions)) {
+            return false;
+        }
+        final FormatDirectiveOptions other = (FormatDirectiveOptions) otherObject;
+        return Objects.equals(this.onlyForFormatter, other.onlyForFormatter)
+                && Objects.equals(this.precision, other.precision)
+                && Objects.equals(this.isLeft, other.isLeft)
+                && Objects.equals(this.isUpper, other.isUpper)
+                && Objects.equals(this.isChCase, other.isChCase)
+                && Objects.equals(this.padding, other.padding)
+                && Objects.equals(this.colons, other.colons);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.onlyForFormatter,
+                this.precision,
+                this.isLeft,
+                this.isUpper,
+                this.isChCase,
+                this.padding,
+                this.colons);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        if (this.isLeft) {
+            builder.append('-');
+        }
+        if (this.isUpper) {
+            builder.append('^');
+        }
+        if (this.isChCase) {
+            builder.append('#');
+        }
+        if (this.padding != '\0') {
+            builder.append(padding);
+        }
+        if (this.colons > 0) {
+            for (int i = 0; i < colons; i++) {
+                builder.append(':');
+            }
+        }
+        if (this.precision > 0) {
+            builder.append(String.valueOf(this.precision));
+        }
+        return builder.toString();
+    }
+
+    static final FormatDirectiveOptions EMPTY = new FormatDirectiveOptions(false, 0, false, false, false, '\0', 0);
+
+    private boolean onlyForFormatter;
+
+    private final int precision;
+    private final boolean isLeft;
+    private final boolean isUpper;
+    private final boolean isChCase;
+    private final char padding;
+    private final int colons;
+}

--- a/src/main/java/org/embulk/util/rubytime/FormatToken.java
+++ b/src/main/java/org/embulk/util/rubytime/FormatToken.java
@@ -16,75 +16,70 @@
 
 package org.embulk.util.rubytime;
 
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * Represents a token instance in Ruby-compatible date-time format strings.
  */
-abstract class FormatToken {
-    abstract boolean isDirective();
-
-    static final class Directive extends FormatToken {
-        Directive(final FormatDirective formatDirective) {
-            this.formatDirective = formatDirective;
-        }
-
-        @Override
-        public boolean equals(final Object otherObject) {
-            if (!(otherObject instanceof Directive)) {
-                return false;
-            }
-            final Directive other = (Directive) otherObject;
-            return this.formatDirective.equals(other.formatDirective);
-        }
-
-        @Override
-        public String toString() {
-            return "<%" + this.formatDirective.toString() + ">";
-        }
-
-        @Override
-        boolean isDirective() {
-            return true;
-        }
-
-        FormatDirective getFormatDirective() {
-            return this.formatDirective;
-        }
-
-        private final FormatDirective formatDirective;
+final class FormatToken {
+    private FormatToken(final String immediate, final FormatDirective directive) {
+        this.immediate = immediate;
+        this.directive = directive;
     }
 
-    static final class Immediate extends FormatToken {
-        Immediate(final char character) {
-            this.string = "" + character;
-        }
+    static FormatToken directive(final FormatDirective directive) {
+        return new FormatToken(null, directive);
+    }
 
-        Immediate(final String string) {
-            this.string = string;
-        }
+    static FormatToken immediate(final char character) {
+        return new FormatToken("" + character, null);
+    }
 
-        @Override
-        public boolean equals(final Object otherObject) {
-            if (!(otherObject instanceof Immediate)) {
-                return false;
-            }
-            final Immediate other = (Immediate) otherObject;
-            return this.string.equals(other.string);
-        }
+    static FormatToken immediate(final String string) {
+        return new FormatToken(string, null);
+    }
 
-        @Override
-        public String toString() {
-            return "<\"" + this.string + "\">";
-        }
-
-        @Override
-        boolean isDirective() {
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (!(otherObject instanceof FormatToken)) {
             return false;
         }
-
-        String getContent() {
-            return this.string;
-        }
-
-        private final String string;
+        final FormatToken other = (FormatToken) otherObject;
+        return Objects.equals(this.immediate, other.immediate)
+                && Objects.equals(this.directive, other.directive);
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.immediate, this.directive);
+    }
+
+    @Override
+    public String toString() {
+        if (this.immediate == null) {
+            return "<%" + this.directive.toString() + ">";
+        } else {
+            return "<\"" + this.immediate + "\">";
+        }
+    }
+
+    boolean isImmediate() {
+        return this.immediate != null;
+    }
+
+    boolean isDirective() {
+        return this.directive != null;
+    }
+
+    Optional<FormatDirective> getFormatDirective() {
+        return Optional.ofNullable(this.directive);
+    }
+
+    Optional<String> getImmediate() {
+        return Optional.ofNullable(this.immediate);
+    }
+
+    private final String immediate;
+    private final FormatDirective directive;
 }

--- a/src/main/java/org/embulk/util/rubytime/FormatToken.java
+++ b/src/main/java/org/embulk/util/rubytime/FormatToken.java
@@ -20,24 +20,42 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Represents a token instance in Ruby-compatible date-time format strings.
+ * Represents a token, a part of a Ruby-compatible date-time format string.
+ *
+ * <p>A token can be an immediate string (e.g. "foo", "T", or else), or a directive.
+ * A directive is a special string piece, starting with {@code '%'}, to be used for
+ * parsing and formatting.
+ *
+ * <p>Even in a directive, it keeps its "immediate string" in it. For example for
+ * {@code "%-000124s"}, it means seconds since epoch, in 124-digit precision,
+ * without padding for a numerical output, but zero-padded (, zero-padded, zero-padded).
+ * So, it means just the same with {@code "%s"}, but the immediate string keeps
+ * the original string {@code "%-000124s"}.
  */
 final class FormatToken {
-    private FormatToken(final String immediate, final FormatDirective directive) {
+    private FormatToken(final String immediate, final FormatDirective directive, final FormatDirectiveOptions options) {
         this.immediate = immediate;
         this.directive = directive;
+        this.options = options;
     }
 
-    static FormatToken directive(final FormatDirective directive) {
-        return new FormatToken(null, directive);
+    static FormatToken directive(
+            final String immediate,
+            final FormatDirective directive,
+            final FormatDirectiveOptions options) {
+        return new FormatToken(immediate, directive, options);
+    }
+
+    static FormatToken directive(final String immediate, final FormatDirective directive) {
+        return new FormatToken(immediate, directive, FormatDirectiveOptions.EMPTY);
     }
 
     static FormatToken immediate(final char character) {
-        return new FormatToken("" + character, null);
+        return new FormatToken("" + character, null, null);
     }
 
     static FormatToken immediate(final String string) {
-        return new FormatToken(string, null);
+        return new FormatToken(string, null, null);
     }
 
     @Override
@@ -47,29 +65,49 @@ final class FormatToken {
         }
         final FormatToken other = (FormatToken) otherObject;
         return Objects.equals(this.immediate, other.immediate)
-                && Objects.equals(this.directive, other.directive);
+                && Objects.equals(this.directive, other.directive)
+                && Objects.equals(this.options, other.options);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.immediate, this.directive);
+        return Objects.hash(this.immediate, this.directive, this.options);
     }
 
     @Override
     public String toString() {
-        if (this.immediate == null) {
-            return "<%" + this.directive.toString() + ">";
+        final StringBuilder builder = new StringBuilder();
+        if (this.directive != null) {
+            builder.append("%");
+            if (this.options != null) {
+                builder.append(this.options.toString());
+            }
+            builder.append(this.directive.toString());
+            if (this.immediate != null) {
+                builder.append("[\"").append(this.immediate).append("\"]");
+            }
         } else {
-            return "<\"" + this.immediate + "\">";
+            builder.append("\"").append(this.immediate).append("\"");
         }
+        return builder.toString();
     }
 
     boolean isImmediate() {
-        return this.immediate != null;
+        return this.directive == null;
     }
 
     boolean isDirective() {
         return this.directive != null;
+    }
+
+    boolean onlyForFormatter() {
+        if (this.isImmediate()) {
+            return false;
+        }
+        if (this.options.onlyForFormatter()) {
+            return true;
+        }
+        return false;
     }
 
     Optional<FormatDirective> getFormatDirective() {
@@ -82,4 +120,5 @@ final class FormatToken {
 
     private final String immediate;
     private final FormatDirective directive;
+    private final FormatDirectiveOptions options;
 }

--- a/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
+++ b/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
@@ -46,6 +46,13 @@ final class ParserWithContext {
         for (final Format.TokenWithNext tokenWithNext : format) {
             final FormatToken token = tokenWithNext.getToken();
 
+            if (token.onlyForFormatter()) {
+                throw new RubyDateTimeParseException(
+                        "Text '" + this.text + "' could not be parsed at index " + this.pos,
+                        this.text,
+                        this.pos);
+            }
+
             if (token.isImmediate()) {
                 this.consumeImmediateString(token.getImmediate().get());
             } else {
@@ -170,7 +177,7 @@ final class ParserWithContext {
                     // %Y, %EY - Year with century (can be negative, 4 digits at least)
                     //           -0001, 0000, 1995, 2009, 14292, etc.
                     case YEAR_WITH_CENTURY:
-                        this.consumeYearWithCentury(builder, tokenWithNext.getNextToken());
+                        this.consumeYearWithCentury(builder, isNumberPattern(tokenWithNext.getNextToken()));
                         break;
 
                     // %y, %Ey, %Oy - year % 100 (00..99)
@@ -186,6 +193,115 @@ final class ParserWithContext {
                     case TIME_ZONE_NAME:
                     case TIME_OFFSET:
                         this.consumeTimeZone(builder);
+                        break;
+
+                    // %% - '%'
+                    case IMMEDIATE_PERCENT:
+                        this.consumeImmediateString("%");
+                        break;
+
+                    // %n - '\n'
+                    case IMMEDIATE_NEWLINE:
+                        this.consumeImmediateString("\n");
+                        break;
+
+                    // %t - '\t'
+                    case IMMEDIATE_TAB:
+                        this.consumeImmediateString("\t");
+                        break;
+
+                    // %c - "%a %b %e %H:%M:%S %Y"
+                    case RECURRED_LOWER_C:
+                        this.consumeWeekName(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeMonthOfYearName(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeDayOfMonth(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeHourOfDay(builder);
+                        this.consumeImmediateString(":");
+                        this.consumeMinuteOfHour(builder);
+                        this.consumeImmediateString(":");
+                        this.consumeSecondOfMinute(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeYearWithCentury(builder, isNumberPattern(tokenWithNext.getNextToken()));  // Last
+                        break;
+
+                    // %D - "%m/%d/%y"
+                    // %X - "%m/%d/%y"
+                    case RECURRED_UPPER_D:
+                    case RECURRED_LOWER_X:
+                        this.consumeMonthOfYear(builder);
+                        this.consumeImmediateString("/");
+                        this.consumeDayOfMonth(builder);
+                        this.consumeImmediateString("/");
+                        this.consumeYearWithoutCentury(builder);
+                        break;
+
+                    // %F - "%Y-%m-%d"
+                    case RECURRED_UPPER_F:
+                        this.consumeYearWithCentury(builder, false);  // Not last
+                        this.consumeImmediateString("-");
+                        this.consumeMonthOfYear(builder);
+                        this.consumeImmediateString("-");
+                        this.consumeDayOfMonth(builder);
+                        break;
+
+                    // %R - "%H:%M"
+                    case RECURRED_UPPER_R:
+                        this.consumeHourOfDay(builder);
+                        this.consumeImmediateString(":");
+                        this.consumeMinuteOfHour(builder);
+                        break;
+
+                    // %r - "%I:%M:%S %p"
+                    case RECURRED_LOWER_R:
+                        this.consumeHourOfAmPm(builder);
+                        this.consumeImmediateString(":");
+                        this.consumeMinuteOfHour(builder);
+                        this.consumeImmediateString(":");
+                        this.consumeSecondOfMinute(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeAmPmOfDay(builder);
+                        break;
+
+                    // %T - "%H:%M:%S"
+                    // %X - "%H:%M:%S"
+                    case RECURRED_UPPER_T:
+                    case RECURRED_UPPER_X:
+                        this.consumeHourOfDay(builder);
+                        this.consumeImmediateString(":");
+                        this.consumeMinuteOfHour(builder);
+                        this.consumeImmediateString(":");
+                        this.consumeSecondOfMinute(builder);
+                        break;
+
+                    // %V - "%e-%b-%Y"
+                    case RECURRED_LOWER_V:
+                        this.consumeDayOfMonth(builder);
+                        this.consumeImmediateString("-");
+                        this.consumeMonthOfYearName(builder);
+                        this.consumeImmediateString("-");
+                        this.consumeYearWithCentury(builder, isNumberPattern(tokenWithNext.getNextToken()));  // Last
+                        break;
+
+                    // %+ - "%a %b %e %H:%M:%S %Z %Y"
+                    case RECURRED_PLUS:
+                        this.consumeWeekName(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeMonthOfYearName(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeDayOfMonth(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeHourOfDay(builder);
+                        this.consumeImmediateString(":");
+                        this.consumeMinuteOfHour(builder);
+                        this.consumeImmediateString(":");
+                        this.consumeSecondOfMinute(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeTimeZone(builder);
+                        this.consumeImmediateString(" ");
+                        this.consumeYearWithCentury(builder, isNumberPattern(tokenWithNext.getNextToken()));  // Last
                         break;
 
                     default:  // Do nothing, and just pass through.
@@ -402,7 +518,7 @@ final class ParserWithContext {
         builder.setDayOfWeekStartingWithSunday0(this.consumeDigitsInInt(1, 0, 6, "invalid day of week"));
     }
 
-    private void consumeYearWithCentury(final Parsed.Builder builder, final FormatToken nextToken) {
+    private void consumeYearWithCentury(final Parsed.Builder builder, final boolean isNextTokenNumber) {
         final boolean negative;
         if (isSign(this.text, this.pos)) {
             negative = (this.text.charAt(this.pos) == '-');
@@ -412,7 +528,7 @@ final class ParserWithContext {
         }
 
         final int yearWithCentury;
-        if (isNumberPattern(nextToken)) {
+        if (isNextTokenNumber) {
             yearWithCentury = this.consumeDigitsInInt(4, 0, 9999, "invalid year");
         } else {
             // JSR-310 accepts only [-999_999_999, 999_999_999] as a year, not [Integer.MIN_VALUE, Integer.MAX_VALUE].

--- a/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
+++ b/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
@@ -228,7 +228,7 @@ final class ParserWithContext {
                         break;
 
                     // %D - "%m/%d/%y"
-                    // %X - "%m/%d/%y"
+                    // %x - "%m/%d/%y"
                     case RECURRED_UPPER_D:
                     case RECURRED_LOWER_X:
                         this.consumeMonthOfYear(builder);

--- a/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
+++ b/src/main/java/org/embulk/util/rubytime/ParserWithContext.java
@@ -46,10 +46,10 @@ final class ParserWithContext {
         for (final Format.TokenWithNext tokenWithNext : format) {
             final FormatToken token = tokenWithNext.getToken();
 
-            if (!token.isDirective()) {
-                this.consumeImmediateString(((FormatToken.Immediate) token).getContent());
+            if (token.isImmediate()) {
+                this.consumeImmediateString(token.getImmediate().get());
             } else {
-                switch (((FormatToken.Directive) token).getFormatDirective()) {
+                switch (token.getFormatDirective().get()) {
                     // %A - The full weekday name (``Sunday'')
                     // %a - The abbreviated name (``Sun'')
                     case DAY_OF_WEEK_FULL_NAME:
@@ -311,7 +311,7 @@ final class ParserWithContext {
 
         final long value;
         if (isNumberPattern(nextToken)) {
-            if (((FormatToken.Directive) thisToken).getFormatDirective() == FormatDirective.MILLI_OF_SECOND) {
+            if (thisToken.getFormatDirective().get() == FormatDirective.MILLI_OF_SECOND) {
                 value = this.consumeFractionalPartInInt(3, 9, "invalid fraction part of second");
             } else {
                 value = this.consumeFractionalPartInInt(9, 9, "invalid fraction part of second");
@@ -383,7 +383,7 @@ final class ParserWithContext {
     }
 
     private void consumeWeekOfYear(final Parsed.Builder builder, final FormatToken thisToken) {
-        if (((FormatToken.Directive) thisToken).getFormatDirective() == FormatDirective.WEEK_OF_YEAR_STARTING_WITH_SUNDAY) {
+        if (thisToken.getFormatDirective().get() == FormatDirective.WEEK_OF_YEAR_STARTING_WITH_SUNDAY) {
             builder.setWeekOfYearStartingWithSunday(this.consumeDigitsInInt(2, 0, 53, "invalid week of year"));
         } else {
             builder.setWeekOfYearStartingWithMonday(this.consumeDigitsInInt(2, 0, 53, "invalid week of year"));
@@ -556,9 +556,9 @@ final class ParserWithContext {
     private static boolean isNumberPattern(final FormatToken token) {
         if (token == null) {
             return false;
-        } else if ((!token.isDirective()) && isDigit(((FormatToken.Immediate) token).getContent().charAt(0))) {
+        } else if (token.isImmediate() && isDigit(token.getImmediate().get().charAt(0))) {
             return true;
-        } else if (token.isDirective() && ((FormatToken.Directive) token).getFormatDirective().isNumeric()) {
+        } else if (token.isDirective() && token.getFormatDirective().get().isNumeric()) {
             return true;
         } else {
             return false;

--- a/src/test/java/org/embulk/util/rubytime/TestFormat.java
+++ b/src/test/java/org/embulk/util/rubytime/TestFormat.java
@@ -17,6 +17,8 @@
 package org.embulk.util.rubytime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
@@ -34,156 +36,118 @@ public class TestFormat {
 
     @Test
     public void testSingles() {
-        testFormat("%Y", FormatDirective.YEAR_WITH_CENTURY.toTokens());
-        testFormat("%C", FormatDirective.CENTURY.toTokens());
-        testFormat("%y", FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+        testFormat("%Y", FormatDirective.YEAR_WITH_CENTURY);
+        testFormat("%C", FormatDirective.CENTURY);
+        testFormat("%y", FormatDirective.YEAR_WITHOUT_CENTURY);
 
-        testFormat("%m", FormatDirective.MONTH_OF_YEAR.toTokens());
-        testFormat("%B", FormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens());
-        testFormat("%b", FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens());
-        testFormat("%h", FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME_ALIAS_SMALL_H.toTokens());
+        testFormat("%m", FormatDirective.MONTH_OF_YEAR);
+        testFormat("%B", FormatDirective.MONTH_OF_YEAR_FULL_NAME);
+        testFormat("%b", FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME);
+        testFormat("%h", FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME_ALIAS_SMALL_H);
 
-        testFormat("%d", FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
-        testFormat("%e", FormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens());
+        testFormat("%d", FormatDirective.DAY_OF_MONTH_ZERO_PADDED);
+        testFormat("%e", FormatDirective.DAY_OF_MONTH_BLANK_PADDED);
 
-        testFormat("%j", FormatDirective.DAY_OF_YEAR.toTokens());
+        testFormat("%j", FormatDirective.DAY_OF_YEAR);
 
-        testFormat("%H", FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens());
-        testFormat("%k", FormatDirective.HOUR_OF_DAY_BLANK_PADDED.toTokens());
-        testFormat("%I", FormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens());
-        testFormat("%l", FormatDirective.HOUR_OF_AMPM_BLANK_PADDED.toTokens());
-        testFormat("%P", FormatDirective.AMPM_OF_DAY_LOWER_CASE.toTokens());
-        testFormat("%p", FormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens());
+        testFormat("%H", FormatDirective.HOUR_OF_DAY_ZERO_PADDED);
+        testFormat("%k", FormatDirective.HOUR_OF_DAY_BLANK_PADDED);
+        testFormat("%I", FormatDirective.HOUR_OF_AMPM_ZERO_PADDED);
+        testFormat("%l", FormatDirective.HOUR_OF_AMPM_BLANK_PADDED);
+        testFormat("%P", FormatDirective.AMPM_OF_DAY_LOWER_CASE);
+        testFormat("%p", FormatDirective.AMPM_OF_DAY_UPPER_CASE);
 
-        testFormat("%M", FormatDirective.MINUTE_OF_HOUR.toTokens());
+        testFormat("%M", FormatDirective.MINUTE_OF_HOUR);
 
-        testFormat("%S", FormatDirective.SECOND_OF_MINUTE.toTokens());
+        testFormat("%S", FormatDirective.SECOND_OF_MINUTE);
 
-        testFormat("%L", FormatDirective.MILLI_OF_SECOND.toTokens());
-        testFormat("%N", FormatDirective.NANO_OF_SECOND.toTokens());
+        testFormat("%L", FormatDirective.MILLI_OF_SECOND);
+        testFormat("%N", FormatDirective.NANO_OF_SECOND);
 
-        testFormat("%z", FormatDirective.TIME_OFFSET.toTokens());
-        testFormat("%Z", FormatDirective.TIME_ZONE_NAME.toTokens());
+        testFormat("%z", FormatDirective.TIME_OFFSET);
+        testFormat("%Z", FormatDirective.TIME_ZONE_NAME);
 
-        testFormat("%A", FormatDirective.DAY_OF_WEEK_FULL_NAME.toTokens());
-        testFormat("%a", FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens());
-        testFormat("%u", FormatDirective.DAY_OF_WEEK_STARTING_WITH_MONDAY_1.toTokens());
-        testFormat("%w", FormatDirective.DAY_OF_WEEK_STARTING_WITH_SUNDAY_0.toTokens());
+        testFormat("%A", FormatDirective.DAY_OF_WEEK_FULL_NAME);
+        testFormat("%a", FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME);
+        testFormat("%u", FormatDirective.DAY_OF_WEEK_STARTING_WITH_MONDAY_1);
+        testFormat("%w", FormatDirective.DAY_OF_WEEK_STARTING_WITH_SUNDAY_0);
 
-        testFormat("%G", FormatDirective.WEEK_BASED_YEAR_WITH_CENTURY.toTokens());
-        testFormat("%g", FormatDirective.WEEK_BASED_YEAR_WITHOUT_CENTURY.toTokens());
-        testFormat("%V", FormatDirective.WEEK_OF_WEEK_BASED_YEAR.toTokens());
+        testFormat("%G", FormatDirective.WEEK_BASED_YEAR_WITH_CENTURY);
+        testFormat("%g", FormatDirective.WEEK_BASED_YEAR_WITHOUT_CENTURY);
+        testFormat("%V", FormatDirective.WEEK_OF_WEEK_BASED_YEAR);
 
-        testFormat("%U", FormatDirective.WEEK_OF_YEAR_STARTING_WITH_SUNDAY.toTokens());
-        testFormat("%W", FormatDirective.WEEK_OF_YEAR_STARTING_WITH_MONDAY.toTokens());
+        testFormat("%U", FormatDirective.WEEK_OF_YEAR_STARTING_WITH_SUNDAY);
+        testFormat("%W", FormatDirective.WEEK_OF_YEAR_STARTING_WITH_MONDAY);
 
-        testFormat("%s", FormatDirective.SECONDS_SINCE_EPOCH.toTokens());
-        testFormat("%Q", FormatDirective.MILLISECONDS_SINCE_EPOCH.toTokens());
+        testFormat("%s", FormatDirective.SECONDS_SINCE_EPOCH);
+        testFormat("%Q", FormatDirective.MILLISECONDS_SINCE_EPOCH);
     }
 
     @Test
     public void testRecurred() {
         testFormat("%c",
-                   FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens());
+                   FormatDirective.RECURRED_LOWER_C);
         testFormat("%D",
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   FormatToken.immediate('/'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate('/'),
-                   FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+                   FormatDirective.RECURRED_UPPER_D);
         testFormat("%x",
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   FormatToken.immediate('/'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate('/'),
-                   FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+                   FormatDirective.RECURRED_LOWER_X);
         testFormat("%F",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   FormatToken.immediate('-'),
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   FormatToken.immediate('-'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
+                   FormatDirective.RECURRED_UPPER_F);
         testFormat("%n",
-                   FormatToken.immediate('\n'));
+                   FormatDirective.IMMEDIATE_NEWLINE);
         testFormat("%R",
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens());
+                   FormatDirective.RECURRED_UPPER_R);
         testFormat("%r",
-                   FormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens());
+                   FormatDirective.RECURRED_LOWER_R);
         testFormat("%T",
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens());
+                   FormatDirective.RECURRED_UPPER_T);
         testFormat("%X",
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens());
+                   FormatDirective.RECURRED_UPPER_X);
         testFormat("%t",
-                   FormatToken.immediate('\t'));
+                   FormatDirective.IMMEDIATE_TAB);
         testFormat("%v",
-                   FormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens(),
-                   FormatToken.immediate('-'),
-                   FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
-                   FormatToken.immediate('-'),
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens());
+                   FormatDirective.RECURRED_LOWER_V);
         testFormat("%+",
-                   FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.TIME_ZONE_NAME.toTokens(),
-                   FormatToken.immediate(' '),
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens());
+                   FormatDirective.RECURRED_PLUS);
     }
 
     @Test
     public void testExtended() {
-        testFormat("%EC", FormatDirective.CENTURY.toTokens());
-        testFormat("%Oy", FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
-        testFormat("%:z", FormatDirective.TIME_OFFSET.toTokens());
-        testFormat("%::z", FormatDirective.TIME_OFFSET.toTokens());
-        testFormat("%:::z", FormatDirective.TIME_OFFSET.toTokens());
+        testFormat("%EC", FormatToken.directive("%EC", FormatDirective.CENTURY));
+        testFormat("%Oy", FormatToken.directive("%Oy", FormatDirective.YEAR_WITHOUT_CENTURY));
+        testFormat("%:z", FormatToken.directive(
+                "%:z", FormatDirective.TIME_OFFSET, FormatDirectiveOptions.builder().setColons(1).build()));
+        assertFalse(Format.compile("%:z").onlyForFormatter());
+        testFormat("%::z", FormatToken.directive(
+                "%::z", FormatDirective.TIME_OFFSET, FormatDirectiveOptions.builder().setColons(2).build()));
+        assertFalse(Format.compile("%::z").onlyForFormatter());
+        testFormat("%:::z", FormatToken.directive(
+                "%:::z", FormatDirective.TIME_OFFSET, FormatDirectiveOptions.builder().setColons(3).build()));
+        assertFalse(Format.compile("%:::z").onlyForFormatter());
+        testFormat("%::::z", FormatToken.directive(
+                "%::::z", FormatDirective.TIME_OFFSET, FormatDirectiveOptions.builder().setColons(4).build()));
+        assertTrue(Format.compile("%::::z").onlyForFormatter());
+
+        testFormat("%0d", FormatToken.directive(
+                "%0d", FormatDirective.DAY_OF_MONTH_ZERO_PADDED, FormatDirectiveOptions.builder().setPadding('0').build()));
+        assertTrue(Format.compile("%0d").onlyForFormatter());
+        testFormat("%12S", FormatToken.directive(
+                "%12S", FormatDirective.SECOND_OF_MINUTE, FormatDirectiveOptions.builder().setPrecision(12).build()));
+        assertTrue(Format.compile("%12S").onlyForFormatter());
+        testFormat("%09M", FormatToken.directive(
+                "%09M", FormatDirective.MINUTE_OF_HOUR,
+                FormatDirectiveOptions.builder().setPadding('0').setPrecision(9).build()));
+        assertTrue(Format.compile("%09M").onlyForFormatter());
     }
 
     @Test
     public void testPercents() {
         testFormat("%", FormatToken.immediate('%'));
-        testFormat("%%", FormatToken.immediate('%'));
+        testFormat("%%", FormatDirective.IMMEDIATE_PERCENT);
 
         // Split into two "%" tokens for some internal reasons.
-        testFormat("%%%", FormatToken.immediate('%'), FormatToken.immediate('%'));
-        testFormat("%%%%", FormatToken.immediate('%'), FormatToken.immediate('%'));
+        testFormat("%%%", FormatDirective.IMMEDIATE_PERCENT, FormatToken.immediate('%'));
+        testFormat("%%%%", FormatDirective.IMMEDIATE_PERCENT, FormatDirective.IMMEDIATE_PERCENT);
     }
 
     @Test
@@ -196,172 +160,151 @@ public class TestFormat {
         testFormat("%f", FormatToken.immediate("%f"));
         testFormat("%Ed", FormatToken.immediate("%Ed"));
         testFormat("%OY", FormatToken.immediate("%OY"));
-        testFormat("%::::z", FormatToken.immediate("%::::z"));
     }
 
     @Test
     public void testSpecifiersAndOrdinary() {
         testFormat("ab%Out%Expose",
                    FormatToken.immediate("ab"),
-                   FormatDirective.DAY_OF_WEEK_STARTING_WITH_MONDAY_1.toTokens(),
+                   FormatToken.directive("%Ou", FormatDirective.DAY_OF_WEEK_STARTING_WITH_MONDAY_1),
                    FormatToken.immediate("t"),
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   FormatToken.immediate('/'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate('/'),
-                   FormatDirective.YEAR_WITHOUT_CENTURY.toTokens(),
+                   FormatToken.directive("%Ex", FormatDirective.RECURRED_LOWER_X),
                    FormatToken.immediate("pose"));
     }
 
     @Test
     public void testRubyTestPatterns() {
         testFormat("%Y-%m-%dT%H:%M:%S",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   FormatDirective.YEAR_WITH_CENTURY,
                    FormatToken.immediate('-'),
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
+                   FormatDirective.MONTH_OF_YEAR,
                    FormatToken.immediate('-'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED,
                    FormatToken.immediate('T'),
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED,
                    FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   FormatDirective.MINUTE_OF_HOUR,
                    FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens());
+                   FormatDirective.SECOND_OF_MINUTE);
         testFormat("%d-%b-%y",
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED,
                    FormatToken.immediate('-'),
-                   FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
+                   FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME,
                    FormatToken.immediate('-'),
-                   FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+                   FormatDirective.YEAR_WITHOUT_CENTURY);
         testFormat("%A %B %d %y",
-                   FormatDirective.DAY_OF_WEEK_FULL_NAME.toTokens(),
+                   FormatDirective.DAY_OF_WEEK_FULL_NAME,
                    FormatToken.immediate(' '),
-                   FormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
+                   FormatDirective.MONTH_OF_YEAR_FULL_NAME,
                    FormatToken.immediate(' '),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED,
                    FormatToken.immediate(' '),
-                   FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+                   FormatDirective.YEAR_WITHOUT_CENTURY);
         testFormat("%B %d, %y",
-                   FormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
+                   FormatDirective.MONTH_OF_YEAR_FULL_NAME,
                    FormatToken.immediate(' '),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED,
                    FormatToken.immediate(", "),
-                   FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+                   FormatDirective.YEAR_WITHOUT_CENTURY);
         testFormat("%B%t%d,%n%y",
-                   FormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
-                   FormatToken.immediate('\t'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   FormatDirective.MONTH_OF_YEAR_FULL_NAME,
+                   FormatDirective.IMMEDIATE_TAB,
+                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED,
                    FormatToken.immediate(','),
-                   FormatToken.immediate('\n'),
-                   FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
+                   FormatDirective.IMMEDIATE_NEWLINE,
+                   FormatDirective.YEAR_WITHOUT_CENTURY);
         testFormat("%I:%M:%S %p",
-                   FormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens(),
+                   FormatDirective.HOUR_OF_AMPM_ZERO_PADDED,
                    FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   FormatDirective.MINUTE_OF_HOUR,
                    FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   FormatDirective.SECOND_OF_MINUTE,
                    FormatToken.immediate(' '),
-                   FormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens());
+                   FormatDirective.AMPM_OF_DAY_UPPER_CASE);
         testFormat("%I:%M:%S %p %Z",
-                   FormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens(),
+                   FormatDirective.HOUR_OF_AMPM_ZERO_PADDED,
                    FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   FormatDirective.MINUTE_OF_HOUR,
                    FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   FormatDirective.SECOND_OF_MINUTE,
                    FormatToken.immediate(' '),
-                   FormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens(),
+                   FormatDirective.AMPM_OF_DAY_UPPER_CASE,
                    FormatToken.immediate(' '),
-                   FormatDirective.TIME_ZONE_NAME.toTokens());
+                   FormatDirective.TIME_ZONE_NAME);
         testFormat("%a%d%b%y%H%p%Z",
-                   FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens(),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
-                   FormatDirective.YEAR_WITHOUT_CENTURY.toTokens(),
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   FormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens(),
-                   FormatDirective.TIME_ZONE_NAME.toTokens());
+                   FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME,
+                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED,
+                   FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME,
+                   FormatDirective.YEAR_WITHOUT_CENTURY,
+                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED,
+                   FormatDirective.AMPM_OF_DAY_UPPER_CASE,
+                   FormatDirective.TIME_ZONE_NAME);
         testFormat("%Y9%m9%d",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   FormatDirective.YEAR_WITH_CENTURY,
                    FormatToken.immediate('9'),
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
+                   FormatDirective.MONTH_OF_YEAR,
                    FormatToken.immediate('9'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
+                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED);
         testFormat("%k%M%S",
-                   FormatDirective.HOUR_OF_DAY_BLANK_PADDED.toTokens(),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens());
+                   FormatDirective.HOUR_OF_DAY_BLANK_PADDED,
+                   FormatDirective.MINUTE_OF_HOUR,
+                   FormatDirective.SECOND_OF_MINUTE);
         testFormat("%l%M%S",
-                   FormatDirective.HOUR_OF_AMPM_BLANK_PADDED.toTokens(),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens());
+                   FormatDirective.HOUR_OF_AMPM_BLANK_PADDED,
+                   FormatDirective.MINUTE_OF_HOUR,
+                   FormatDirective.SECOND_OF_MINUTE);
         testFormat("%Y.",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   FormatDirective.YEAR_WITH_CENTURY,
                    FormatToken.immediate('.'));
         testFormat("%Y. ",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   FormatDirective.YEAR_WITH_CENTURY,
                    FormatToken.immediate(". "));
         testFormat("%Y-%m-%d",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   FormatDirective.YEAR_WITH_CENTURY,
                    FormatToken.immediate('-'),
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
+                   FormatDirective.MONTH_OF_YEAR,
                    FormatToken.immediate('-'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
+                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED);
         testFormat("%Y-%m-%e",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   FormatDirective.YEAR_WITH_CENTURY,
                    FormatToken.immediate('-'),
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
+                   FormatDirective.MONTH_OF_YEAR,
                    FormatToken.immediate('-'),
-                   FormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens());
+                   FormatDirective.DAY_OF_MONTH_BLANK_PADDED);
         testFormat("%Y-%j",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
+                   FormatDirective.YEAR_WITH_CENTURY,
                    FormatToken.immediate('-'),
-                   FormatDirective.DAY_OF_YEAR.toTokens());
+                   FormatDirective.DAY_OF_YEAR);
         testFormat("%H:%M:%S",
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
+                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED,
                    FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   FormatDirective.MINUTE_OF_HOUR,
                    FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens());
+                   FormatDirective.SECOND_OF_MINUTE);
         testFormat("%k:%M:%S",
-                   FormatDirective.HOUR_OF_DAY_BLANK_PADDED.toTokens(),
+                   FormatDirective.HOUR_OF_DAY_BLANK_PADDED,
                    FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
+                   FormatDirective.MINUTE_OF_HOUR,
                    FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens());
+                   FormatDirective.SECOND_OF_MINUTE);
         testFormat("%A,",
-                   FormatDirective.DAY_OF_WEEK_FULL_NAME.toTokens(),
+                   FormatDirective.DAY_OF_WEEK_FULL_NAME,
                    FormatToken.immediate(','));
         testFormat("%B,",
-                   FormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
+                   FormatDirective.MONTH_OF_YEAR_FULL_NAME,
                    FormatToken.immediate(','));
         testFormat("%FT%T%Z",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   FormatToken.immediate('-'),
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   FormatToken.immediate('-'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   FormatDirective.RECURRED_UPPER_F,
                    FormatToken.immediate('T'),
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   FormatDirective.TIME_ZONE_NAME.toTokens());
+                   FormatDirective.RECURRED_UPPER_T,
+                   FormatDirective.TIME_ZONE_NAME);
         testFormat("%FT%T.%N%Z",
-                   FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   FormatToken.immediate('-'),
-                   FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   FormatToken.immediate('-'),
-                   FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
+                   FormatDirective.RECURRED_UPPER_F,
                    FormatToken.immediate('T'),
-                   FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   FormatToken.immediate(':'),
-                   FormatDirective.SECOND_OF_MINUTE.toTokens(),
+                   FormatDirective.RECURRED_UPPER_T,
                    FormatToken.immediate('.'),
-                   FormatDirective.NANO_OF_SECOND.toTokens(),
-                   FormatDirective.TIME_ZONE_NAME.toTokens());
+                   FormatDirective.NANO_OF_SECOND,
+                   FormatDirective.TIME_ZONE_NAME);
     }
 
     private void testFormat(final String formatString, final Object... expectedTokensInArray) {
@@ -369,14 +312,11 @@ public class TestFormat {
         for (final Object expectedElement : expectedTokensInArray) {
             if (expectedElement instanceof FormatToken) {
                 expectedTokens.add((FormatToken) expectedElement);
-            } else if (expectedElement instanceof List) {
-                for (final Object expectedElement2 : (List) expectedElement) {
-                    if (expectedElement2 instanceof FormatToken) {
-                        expectedTokens.add((FormatToken) expectedElement2);
-                    } else {
-                        fail("Not Token");
-                    }
-                }
+            } else if (expectedElement instanceof FormatDirective) {
+                expectedTokens.add(FormatToken.directive(
+                        "%" + ((FormatDirective) expectedElement).getSpecifier(),
+                        (FormatDirective) expectedElement,
+                        FormatDirectiveOptions.EMPTY));
             } else {
                 fail("Neither Token nor List");
             }

--- a/src/test/java/org/embulk/util/rubytime/TestFormat.java
+++ b/src/test/java/org/embulk/util/rubytime/TestFormat.java
@@ -85,85 +85,85 @@ public class TestFormat {
     public void testRecurred() {
         testFormat("%c",
                    FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.YEAR_WITH_CENTURY.toTokens());
         testFormat("%D",
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('/'),
+                   FormatToken.immediate('/'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate('/'),
+                   FormatToken.immediate('/'),
                    FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
         testFormat("%x",
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('/'),
+                   FormatToken.immediate('/'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate('/'),
+                   FormatToken.immediate('/'),
                    FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
         testFormat("%F",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
         testFormat("%n",
-                   new FormatToken.Immediate('\n'));
+                   FormatToken.immediate('\n'));
         testFormat("%R",
                    FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens());
         testFormat("%r",
                    FormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens());
         testFormat("%T",
                    FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens());
         testFormat("%X",
                    FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens());
         testFormat("%t",
-                   new FormatToken.Immediate('\t'));
+                   FormatToken.immediate('\t'));
         testFormat("%v",
                    FormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.YEAR_WITH_CENTURY.toTokens());
         testFormat("%+",
                    FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.TIME_ZONE_NAME.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.YEAR_WITH_CENTURY.toTokens());
     }
 
@@ -178,99 +178,99 @@ public class TestFormat {
 
     @Test
     public void testPercents() {
-        testFormat("%", new FormatToken.Immediate('%'));
-        testFormat("%%", new FormatToken.Immediate('%'));
+        testFormat("%", FormatToken.immediate('%'));
+        testFormat("%%", FormatToken.immediate('%'));
 
         // Split into two "%" tokens for some internal reasons.
-        testFormat("%%%", new FormatToken.Immediate('%'), new FormatToken.Immediate('%'));
-        testFormat("%%%%", new FormatToken.Immediate('%'), new FormatToken.Immediate('%'));
+        testFormat("%%%", FormatToken.immediate('%'), FormatToken.immediate('%'));
+        testFormat("%%%%", FormatToken.immediate('%'), FormatToken.immediate('%'));
     }
 
     @Test
     public void testOrdinary() {
-        testFormat("abc123", new FormatToken.Immediate("abc123"));
+        testFormat("abc123", FormatToken.immediate("abc123"));
     }
 
     @Test
     public void testPercentButOrdinary() {
-        testFormat("%f", new FormatToken.Immediate("%f"));
-        testFormat("%Ed", new FormatToken.Immediate("%Ed"));
-        testFormat("%OY", new FormatToken.Immediate("%OY"));
-        testFormat("%::::z", new FormatToken.Immediate("%::::z"));
+        testFormat("%f", FormatToken.immediate("%f"));
+        testFormat("%Ed", FormatToken.immediate("%Ed"));
+        testFormat("%OY", FormatToken.immediate("%OY"));
+        testFormat("%::::z", FormatToken.immediate("%::::z"));
     }
 
     @Test
     public void testSpecifiersAndOrdinary() {
         testFormat("ab%Out%Expose",
-                   new FormatToken.Immediate("ab"),
+                   FormatToken.immediate("ab"),
                    FormatDirective.DAY_OF_WEEK_STARTING_WITH_MONDAY_1.toTokens(),
-                   new FormatToken.Immediate("t"),
+                   FormatToken.immediate("t"),
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('/'),
+                   FormatToken.immediate('/'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate('/'),
+                   FormatToken.immediate('/'),
                    FormatDirective.YEAR_WITHOUT_CENTURY.toTokens(),
-                   new FormatToken.Immediate("pose"));
+                   FormatToken.immediate("pose"));
     }
 
     @Test
     public void testRubyTestPatterns() {
         testFormat("%Y-%m-%dT%H:%M:%S",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate('T'),
+                   FormatToken.immediate('T'),
                    FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens());
         testFormat("%d-%b-%y",
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
         testFormat("%A %B %d %y",
                    FormatDirective.DAY_OF_WEEK_FULL_NAME.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
         testFormat("%B %d, %y",
                    FormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(", "),
+                   FormatToken.immediate(", "),
                    FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
         testFormat("%B%t%d,%n%y",
                    FormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
-                   new FormatToken.Immediate('\t'),
+                   FormatToken.immediate('\t'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(','),
-                   new FormatToken.Immediate('\n'),
+                   FormatToken.immediate(','),
+                   FormatToken.immediate('\n'),
                    FormatDirective.YEAR_WITHOUT_CENTURY.toTokens());
         testFormat("%I:%M:%S %p",
                    FormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens());
         testFormat("%I:%M:%S %p %Z",
                    FormatDirective.HOUR_OF_AMPM_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.AMPM_OF_DAY_UPPER_CASE.toTokens(),
-                   new FormatToken.Immediate(' '),
+                   FormatToken.immediate(' '),
                    FormatDirective.TIME_ZONE_NAME.toTokens());
         testFormat("%a%d%b%y%H%p%Z",
                    FormatDirective.DAY_OF_WEEK_ABBREVIATED_NAME.toTokens(),
@@ -282,9 +282,9 @@ public class TestFormat {
                    FormatDirective.TIME_ZONE_NAME.toTokens());
         testFormat("%Y9%m9%d",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate('9'),
+                   FormatToken.immediate('9'),
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('9'),
+                   FormatToken.immediate('9'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
         testFormat("%k%M%S",
                    FormatDirective.HOUR_OF_DAY_BLANK_PADDED.toTokens(),
@@ -296,70 +296,70 @@ public class TestFormat {
                    FormatDirective.SECOND_OF_MINUTE.toTokens());
         testFormat("%Y.",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate('.'));
+                   FormatToken.immediate('.'));
         testFormat("%Y. ",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate(". "));
+                   FormatToken.immediate(". "));
         testFormat("%Y-%m-%d",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens());
         testFormat("%Y-%m-%e",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.DAY_OF_MONTH_BLANK_PADDED.toTokens());
         testFormat("%Y-%j",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.DAY_OF_YEAR.toTokens());
         testFormat("%H:%M:%S",
                    FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens());
         testFormat("%k:%M:%S",
                    FormatDirective.HOUR_OF_DAY_BLANK_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens());
         testFormat("%A,",
                    FormatDirective.DAY_OF_WEEK_FULL_NAME.toTokens(),
-                   new FormatToken.Immediate(','));
+                   FormatToken.immediate(','));
         testFormat("%B,",
                    FormatDirective.MONTH_OF_YEAR_FULL_NAME.toTokens(),
-                   new FormatToken.Immediate(','));
+                   FormatToken.immediate(','));
         testFormat("%FT%T%Z",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate('T'),
+                   FormatToken.immediate('T'),
                    FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens(),
                    FormatDirective.TIME_ZONE_NAME.toTokens());
         testFormat("%FT%T.%N%Z",
                    FormatDirective.YEAR_WITH_CENTURY.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.MONTH_OF_YEAR.toTokens(),
-                   new FormatToken.Immediate('-'),
+                   FormatToken.immediate('-'),
                    FormatDirective.DAY_OF_MONTH_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate('T'),
+                   FormatToken.immediate('T'),
                    FormatDirective.HOUR_OF_DAY_ZERO_PADDED.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.MINUTE_OF_HOUR.toTokens(),
-                   new FormatToken.Immediate(':'),
+                   FormatToken.immediate(':'),
                    FormatDirective.SECOND_OF_MINUTE.toTokens(),
-                   new FormatToken.Immediate('.'),
+                   FormatToken.immediate('.'),
                    FormatDirective.NANO_OF_SECOND.toTokens(),
                    FormatDirective.TIME_ZONE_NAME.toTokens());
     }

--- a/src/test/java/org/embulk/util/rubytime/TestFormat.java
+++ b/src/test/java/org/embulk/util/rubytime/TestFormat.java
@@ -128,6 +128,22 @@ public class TestFormat {
                 "%::::z", FormatDirective.TIME_OFFSET, FormatDirectiveOptions.builder().setColons(4).build()));
         assertTrue(Format.compile("%::::z").onlyForFormatter());
 
+        testFormat("%-S", FormatToken.directive(
+                "%-S", FormatDirective.SECOND_OF_MINUTE, FormatDirectiveOptions.builder().setLeft().build()));
+        assertTrue(Format.compile("%-S").onlyForFormatter());
+
+        testFormat("%^A", FormatToken.directive(
+                "%^A", FormatDirective.DAY_OF_WEEK_FULL_NAME, FormatDirectiveOptions.builder().setUpper().build()));
+        assertTrue(Format.compile("%^A").onlyForFormatter());
+
+        testFormat("%#b", FormatToken.directive(
+                "%#b", FormatDirective.MONTH_OF_YEAR_ABBREVIATED_NAME, FormatDirectiveOptions.builder().setChCase().build()));
+        assertTrue(Format.compile("%#b").onlyForFormatter());
+
+        testFormat("%_M", FormatToken.directive(
+                       "%_M", FormatDirective.MINUTE_OF_HOUR, FormatDirectiveOptions.builder().setPadding(' ').build()));
+        assertTrue(Format.compile("%_M").onlyForFormatter());
+
         testFormat("%0d", FormatToken.directive(
                 "%0d", FormatDirective.DAY_OF_MONTH_ZERO_PADDED, FormatDirectiveOptions.builder().setPadding('0').build()));
         assertTrue(Format.compile("%0d").onlyForFormatter());


### PR DESCRIPTION
This library has supported only parsing (`Time.strptime`) of Ruby. Since v0.3.0, it is going to support formatting (`Time#strftime`) in addition.

They have similar format patterns (such as `%y-%m-%d %H:%M:%S`), but a little bit different. The biggest difference is that the formatter `strftime` accepts options like `%-012s` while the parser `strptime` does not accept options.

This library has accepted only formats without options. To support formatting, this PR is to support options in formats. One point is that the parser still needs to "reject" formats with options to be compatible with Ruby.

----

To make it available simply, it starts to process "recurred directives" as-is, not to be expanded immediately. Recurred directives are like `%c` that is expanded to `%a %b %e %T %Y`.
https://docs.ruby-lang.org/en/2.6.0/DateTime.html#method-i-strftime

An option like `-012` is available also for recurred directives. Expanding it immediately was not very straightforward to handle such an option.