### PR TITLE
Support formatting short zone names such as PST, PDT, and JST like org.jruby.util.RubyDateFormat

### DIFF
--- a/src/jrubyTest/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterFormatWithJRuby.java
+++ b/src/jrubyTest/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterFormatWithJRuby.java
@@ -65,8 +65,8 @@ public class TestRubyDateTimeFormatterFormatWithJRuby {
         final RubyDateTimeFormatter formatter = RubyDateTimeFormatter.ofPattern(format);
         final String actual = formatter.formatWithZoneNameStyle(datetime, RubyDateTimeFormatter.ZoneNameStyle.SHORT);
 
-        System.out.println(expected);
-        System.out.println(actual);
+        System.out.println("Expected: " + expected);
+        System.out.println("  Actual: " + actual);
         assertEquals(expected, actual);
     }
 
@@ -85,8 +85,8 @@ public class TestRubyDateTimeFormatterFormatWithJRuby {
         final RubyDateTimeFormatter formatter = RubyDateTimeFormatter.ofPattern(format);
         final String actual = formatter.formatWithZoneNameStyle(datetime, RubyDateTimeFormatter.ZoneNameStyle.SHORT);
 
-        System.out.println(expected);
-        System.out.println(actual);
+        System.out.println("Expected: " + expected);
+        System.out.println("  Actual: " + actual);
         assertEquals(expected, actual);
     }
 

--- a/src/jrubyTest/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterFormatWithJRuby.java
+++ b/src/jrubyTest/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterFormatWithJRuby.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.rubytime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests formatting by RubyDateTimeFormatter with JRuby's org.jruby.util.RubyDateFormat.
+ *
+ * <p>The main purpose of these tests is to confirm it works almost the same with org.jruby.util.RubyDateFormat.
+ * Embulk's legacy {@code TimestampFormatter} has used {@code org.jruby.util.RubyDateFormat} for a long time.
+ */
+public class TestRubyDateTimeFormatterFormatWithJRuby {
+    @ParameterizedTest
+    @MethodSource("provideZonedDateTime")
+    public void testZonedDateTime(final ZonedDateTime datetime) {
+        assertRubyDateFormat(datetime);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideOffsetDateTime")
+    public void testOffsetDateTime(final OffsetDateTime datetime) {
+        assertRubyDateFormat(datetime);
+    }
+
+    @SuppressWarnings("deprecation")  // For use of org.jruby.util.RubyDateFormat.
+    private void assertRubyDateFormat(final ZonedDateTime datetime) {
+        final String format = "%Y-%m-%dT%H:%M:%S %Z";
+
+        final org.jruby.util.RubyDateFormat jrubyFormat = new org.jruby.util.RubyDateFormat(format, Locale.ROOT, true);
+        final DateTime jodaDateTime = new DateTime(
+                datetime.toInstant().toEpochMilli(),
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(datetime.getZone())));
+        jrubyFormat.setDateTime(jodaDateTime);
+        jrubyFormat.setNSec(datetime.getNano() / 1000);
+        final String expected = jrubyFormat.format(null);
+
+        final RubyDateTimeFormatter formatter = RubyDateTimeFormatter.ofPattern(format);
+        final String actual = formatter.formatWithZoneNameStyle(datetime, RubyDateTimeFormatter.ZoneNameStyle.SHORT);
+
+        System.out.println(expected);
+        System.out.println(actual);
+        assertEquals(expected, actual);
+    }
+
+    @SuppressWarnings("deprecation")  // For use of org.jruby.util.RubyDateFormat.
+    private void assertRubyDateFormat(final OffsetDateTime datetime) {
+        final String format = "%Y-%m-%dT%H:%M:%S %Z";
+
+        final org.jruby.util.RubyDateFormat jrubyFormat = new org.jruby.util.RubyDateFormat(format, Locale.ROOT, true);
+        final DateTime jodaDateTime = new DateTime(
+                datetime.toInstant().toEpochMilli(),
+                DateTimeZone.forOffsetMillis(datetime.getOffset().getTotalSeconds() * 1000));
+        jrubyFormat.setDateTime(jodaDateTime);
+        jrubyFormat.setNSec(datetime.getNano() / 1000);
+        final String expected = jrubyFormat.format(null);
+
+        final RubyDateTimeFormatter formatter = RubyDateTimeFormatter.ofPattern(format);
+        final String actual = formatter.formatWithZoneNameStyle(datetime, RubyDateTimeFormatter.ZoneNameStyle.SHORT);
+
+        System.out.println(expected);
+        System.out.println(actual);
+        assertEquals(expected, actual);
+    }
+
+    private static Stream<ZonedDateTime> provideZonedDateTime() {
+        return Arrays.stream(ZONED_DATE_TIMES);
+    }
+
+    private static Stream<OffsetDateTime> provideOffsetDateTime() {
+        return Arrays.stream(OFFSET_DATE_TIMES);
+    }
+
+    private static final ZonedDateTime[] ZONED_DATE_TIMES = {
+        ZonedDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneId.of("Asia/Tokyo")),
+        ZonedDateTime.of(2017, 7, 3, 2, 0, 45, 0, ZoneId.of("Asia/Tokyo")),
+        ZonedDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneId.of("America/Los_Angeles")),
+        ZonedDateTime.of(2017, 7, 3, 2, 0, 45, 0, ZoneId.of("America/Los_Angeles")),
+        ZonedDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneId.of("America/Chicago")),
+        ZonedDateTime.of(2017, 7, 3, 2, 0, 45, 0, ZoneId.of("America/Chicago")),
+        ZonedDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneId.of("Asia/Harbin")),
+        ZonedDateTime.of(2017, 7, 3, 2, 0, 45, 0, ZoneId.of("Asia/Harbin")),
+        ZonedDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneId.of("Europe/London")),
+        ZonedDateTime.of(2017, 7, 3, 2, 0, 45, 0, ZoneId.of("Europe/London")),
+        ZonedDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneId.of("Africa/Windhoek")),
+        ZonedDateTime.of(2017, 7, 3, 2, 0, 45, 0, ZoneId.of("Africa/Windhoek")),
+        ZonedDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneId.of("America/Grand_Turk")),
+        ZonedDateTime.of(2017, 7, 3, 2, 0, 45, 0, ZoneId.of("America/Grand_Turk")),
+
+        // The tzdb embedded in JRuby 9.1.15.0 / Joda-Time 2.9.2 may be just too old.
+        // They don't catch up with the latest daylight saving time status -- then testing with older date.
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("America/Santiago")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("America/Santiago")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Asia/Baku")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Asia/Baku")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Asia/Choibalsan")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Asia/Choibalsan")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Asia/Hovd")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Asia/Hovd")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Asia/Istanbul")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Asia/Istanbul")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Asia/Ulaanbaatar")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Asia/Ulaanbaatar")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Asia/Ulan_Bator")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Asia/Ulan_Bator")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Chile/Continental")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Chile/Continental")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Chile/EasterIsland")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Chile/EasterIsland")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Europe/Istanbul")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Europe/Istanbul")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Pacific/Easter")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Pacific/Easter")),
+        ZonedDateTime.of(1996, 1, 3, 2, 0, 45, 0, ZoneId.of("Turkey")),
+        ZonedDateTime.of(1996, 7, 3, 2, 0, 45, 0, ZoneId.of("Turkey")),
+
+        ZonedDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneOffset.UTC),
+        ZonedDateTime.of(2017, 7, 3, 2, 0, 45, 0, ZoneOffset.UTC),
+        ZonedDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneOffset.ofHours(9)),
+        ZonedDateTime.of(2017, 7, 3, 2, 0, 45, 0, ZoneOffset.ofHours(9)),
+    };
+
+    private static final OffsetDateTime[] OFFSET_DATE_TIMES = {
+        OffsetDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneOffset.UTC),
+        OffsetDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneOffset.ofTotalSeconds(0)),
+        OffsetDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneOffset.ofTotalSeconds(7)),
+        OffsetDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneOffset.ofHoursMinutes(11, 15)),
+        OffsetDateTime.of(2017, 1, 3, 2, 0, 45, 0, ZoneOffset.ofHours(9)),
+    };
+}

--- a/src/main/java/org/embulk/util/rubytime/RubyDateTimeFormatter.java
+++ b/src/main/java/org/embulk/util/rubytime/RubyDateTimeFormatter.java
@@ -32,6 +32,22 @@ public final class RubyDateTimeFormatter {
     }
 
     /**
+     * Enumeration of the style of zone name formatting.
+     */
+    public enum ZoneNameStyle {
+        /**
+         * Formats into {@code "UTC"} when the offset is +00:00. Otherwise {@code ""}.
+         */
+        NONE,
+
+        /**
+         * Formats into short zone names such as {@code "PST"}, {@code "PDT"}, {@code "JST"}, and else.
+         */
+        SHORT,
+        ;
+    }
+
+    /**
      * Creates a formatter using the specified pattern with the default resolver similar to Ruby's {@code Time.strptime}.
      *
      * @param pattern  the pattern to use, not null
@@ -53,6 +69,27 @@ public final class RubyDateTimeFormatter {
      */
     public String format(final TemporalAccessor temporal) {
         return (new FormatterWithContext(temporal)).format(this.format);
+    }
+
+    /**
+     * Formats a date-time object using this formatter with the zone name style specified.
+     *
+     * <p>If {@code zoneNameStyle} is {@link ZoneNameStyle#NONE}, {@code "%Z"} is formatted into {@code "UTC"}
+     * only when the offset is +00:00. Otherwise, formatted into {@code ""}. It follows the basic behavior of
+     * Ruby's {@code Time.strftime}.
+     *
+     * <p>If {@code zoneNameStyle} is {@link ZoneNameStyle#SHORT}, {@code "%Z"} is formatted into short zone names
+     * such as {@code "PST"}, {@code "PDT"}, {@code "JST"}, and else.
+     *
+     * @param temporal  the temporal object to format, not null
+     * @param zoneNameStyle  the style of zone name formatting
+     *
+     * @return the formatted string, not null
+     *
+     * @throws RubyDateTimeParseException  if the parse results in an error
+     */
+    public String formatWithZoneNameStyle(final TemporalAccessor temporal, final ZoneNameStyle zoneNameStyle) {
+        return (new FormatterWithContext(temporal)).format(this.format, zoneNameStyle);
     }
 
     /**


### PR DESCRIPTION
While the existing formatting behavior with time zone names is compliant with CRuby/JRuby's `Time.strftime`, it was a bit different from JRuby's internal class `org.jruby.util.RubyDateFormat`. `org.jruby.util.RubyDateFormat` has formatted `"%Z"` (time zone name) into a short zone name such as `"PST"`, `"PDT"`, or `"JST"`.

* https://github.com/jruby/jruby/blob/9.1.15.0/core/src/main/java/org/jruby/util/RubyDateFormat.java

----

On the other hand, Embulk's legacy `TimestampFormatter` has used this `org.jruby.util.RubyDateFormat` internally for a long time.

* https://github.com/embulk/embulk/blob/v0.10.2/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormatterRuby.java#L20

We're going to replace the use of `org.jruby.util.RubyDateFormat` with `embulk-util-rubytime` to eliminate direct dependency on JRuby from Embulk. To avoid breaking compatiblity without workarounds in later Embulk, `embulk-util-rubytime` has to provide some support with the "short zone names".

----

Unfortunately, use of such short zone names is strongly discouraged in recent Java APIs, and not provided in modern `java.time` APIs, because they are not unique such as "CST" for U.S. "Central Standard Time" and "China Standard Time".

* "Three-letter time zone IDs" in https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html

So, this PR tries emulating the behavior with utilizing the older `java.util.TimeZone` class and its `getDisplayName` method.

* https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html#getDisplayName-boolean-int-java.util.Locale-