### PR TITLE
Enable the chcase option ('#') for short zone names

### DIFF
--- a/src/jrubyTest/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterFormatWithJRuby.java
+++ b/src/jrubyTest/java/org/embulk/util/rubytime/TestRubyDateTimeFormatterFormatWithJRuby.java
@@ -52,7 +52,7 @@ public class TestRubyDateTimeFormatterFormatWithJRuby {
 
     @SuppressWarnings("deprecation")  // For use of org.jruby.util.RubyDateFormat.
     private void assertRubyDateFormat(final ZonedDateTime datetime) {
-        final String format = "%Y-%m-%dT%H:%M:%S %Z";
+        final String format = "%Y-%m-%dT%H:%M:%S %Z %#Z";
 
         final org.jruby.util.RubyDateFormat jrubyFormat = new org.jruby.util.RubyDateFormat(format, Locale.ROOT, true);
         final DateTime jodaDateTime = new DateTime(
@@ -72,7 +72,7 @@ public class TestRubyDateTimeFormatterFormatWithJRuby {
 
     @SuppressWarnings("deprecation")  // For use of org.jruby.util.RubyDateFormat.
     private void assertRubyDateFormat(final OffsetDateTime datetime) {
-        final String format = "%Y-%m-%dT%H:%M:%S %Z";
+        final String format = "%Y-%m-%dT%H:%M:%S %Z %#Z";
 
         final org.jruby.util.RubyDateFormat jrubyFormat = new org.jruby.util.RubyDateFormat(format, Locale.ROOT, true);
         final DateTime jodaDateTime = new DateTime(

--- a/src/main/java/org/embulk/util/rubytime/FormatterWithContext.java
+++ b/src/main/java/org/embulk/util/rubytime/FormatterWithContext.java
@@ -710,7 +710,11 @@ final class FormatterWithContext {
                 if (zoneId.isPresent() && zoneId.get() instanceof ZoneOffset) {
                     final String shortName;
                     if (((ZoneOffset) (zoneId.get())).getTotalSeconds() == 0) {
-                        shortName = "UTC";
+                        if (options.isChCase()) {
+                            shortName = "utc";
+                        } else {
+                            shortName = "UTC";
+                        }
                     } else {
                         shortName = zoneId.get().getDisplayName(TextStyle.SHORT, Locale.ROOT);
                     }
@@ -723,7 +727,11 @@ final class FormatterWithContext {
                     final boolean inDaylightTime = isInDaylightTime(legacyTimeZone, this.temporal);
                     final String shortName = legacyTimeZone.getDisplayName(inDaylightTime, TimeZone.SHORT, Locale.ROOT);
                     this.fillPadding(builder, options, ' ', 0, shortName.length());
-                    builder.append(shortName);
+                    if (options.isChCase()) {
+                        builder.append(shortName.toLowerCase());
+                    } else {
+                        builder.append(shortName);
+                    }
                 } else {
                     this.fillPadding(builder, options, ' ', 0, 0);
                     builder.append("");


### PR DESCRIPTION
It's a follow-up to #58. The chcase option (`"%#Z"`) was not working well for short zone names.